### PR TITLE
Update dependencies: arrow 59, pyo3 0.29, thiserror 2, Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,60 @@
+version: 2
+
+updates:
+  # Rust: one manifest set for the whole cargo workspace (root Cargo.toml plus
+  # core/, py/, json/) -- Dependabot resolves workspace members from the root.
+  - package-ecosystem: cargo
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 5
+    groups:
+      # The arrow family must move in lockstep: `arrow`'s `pyarrow` feature ties
+      # the arrow version to a specific pyo3 major via `arrow-pyarrow`, so
+      # splitting these across PRs produces trees that do not type-check.
+      arrow:
+        patterns:
+          - "arrow"
+          - "arrow-*"
+          - "parquet"
+          - "pyo3"
+      # Everything else that is not a major bump rolls up into a single PR.
+      cargo-minor-patch:
+        patterns:
+          - "*"
+        exclude-patterns:
+          - "arrow"
+          - "arrow-*"
+          - "parquet"
+          - "pyo3"
+        update-types:
+          - minor
+          - patch
+
+  # Workflow actions are pinned to commit SHAs (with a `# vX.Y.Z` comment);
+  # Dependabot understands and preserves that format when it bumps them.
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: monday
+    groups:
+      actions:
+        patterns:
+          - "*"
+
+  # The uv lockfile for the dev/test environment (root pyproject.toml plus the
+  # py/ and json/ workspace members).
+  - package-ecosystem: uv
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: monday
+    groups:
+      python-minor-patch:
+        patterns:
+          - "*"
+        update-types:
+          - minor
+          - patch

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -57,9 +57,9 @@ dependencies = [
 
 [[package]]
 name = "aho-corasick"
-version = "1.1.4"
+version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+checksum = "c982642fa9e8606056828ee9a8505737230110bb1099153c79efe865c59d12ba"
 dependencies = [
  "memchr",
 ]
@@ -72,9 +72,9 @@ checksum = "cc7bb162ec39d46ab1ca8c77bf72e890535becd1751bb45f64c597edb4c8c6b3"
 
 [[package]]
 name = "alloc-stdlib"
-version = "0.2.2"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94fb8275041c72129eb51b7d0322c29b8387a0386127718b096429201a5d6ece"
+checksum = "0e76a019e91224d279006ff972f1e984179a6e9feb050adba6ce8274aef23195"
 dependencies = [
  "alloc-no-stdlib",
 ]
@@ -96,9 +96,9 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "android_system_properties"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+checksum = "ae221649c9976a6f6c56ae1facf410f3ddb33cc661c4b7b61020a912d4237fbc"
 dependencies = [
  "libc",
 ]
@@ -111,27 +111,27 @@ checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
 name = "anstyle"
-version = "1.0.13"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
 
 [[package]]
 name = "anyhow"
-version = "1.0.100"
+version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
+checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
 name = "arrayvec"
-version = "0.7.6"
+version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+checksum = "d3fb67a6e08acf24fdeccbac2cb6ac4305825bd1f117462e0e6f2f193345ad56"
 
 [[package]]
 name = "arrow"
-version = "56.0.0"
+version = "59.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd798aea3553913a5986813e9c6ad31a2d2b04e931fe8ea4a37155eb541cebb5"
+checksum = "61d285d16bce7d0be61912f7928342b673067b6b7d7ef6cc179258ba7de1fecf"
 dependencies = [
  "arrow-arith",
  "arrow-array",
@@ -151,23 +151,23 @@ dependencies = [
 
 [[package]]
 name = "arrow-arith"
-version = "56.0.0"
+version = "59.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "508dafb53e5804a238cab7fd97a59ddcbfab20cc4d9814b1ab5465b9fa147f2e"
+checksum = "757ef1836251e88222542a7da2623bc1c9cb9e20afefa6db2c41e79991cd91d4"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
  "arrow-data",
  "arrow-schema",
  "chrono",
- "num",
+ "num-traits",
 ]
 
 [[package]]
 name = "arrow-array"
-version = "56.0.0"
+version = "59.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2730bc045d62bb2e53ef8395b7d4242f5c8102f41ceac15e8395b9ac3d08461"
+checksum = "bc9a4a4b2b5ecd0e04df03471661cb61f28bed3c7fd50994715129b01b2edb97"
 dependencies = [
  "ahash 0.8.12",
  "arrow-buffer",
@@ -175,46 +175,51 @@ dependencies = [
  "arrow-schema",
  "chrono",
  "half",
- "hashbrown 0.15.5",
- "num",
+ "hashbrown 0.17.1",
+ "libc",
+ "num-complex",
+ "num-integer",
+ "num-traits",
 ]
 
 [[package]]
 name = "arrow-buffer"
-version = "56.2.0"
+version = "59.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e003216336f70446457e280807a73899dd822feaf02087d31febca1363e2fccc"
+checksum = "c12b576ef18c1deb80925a248b25ad84f419198d791b8e293fc6aaa60441fe90"
 dependencies = [
  "bytes",
  "half",
- "num",
+ "num-bigint",
+ "num-traits",
 ]
 
 [[package]]
 name = "arrow-cast"
-version = "56.0.0"
+version = "59.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67e8bcb7dc971d779a7280593a1bf0c2743533b8028909073e804552e85e75b5"
+checksum = "68338a9096a5dc9bc11927c58c43a8526d96bf6abd2012ef6c0c9f505991cc79"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
  "arrow-data",
+ "arrow-ord",
  "arrow-schema",
  "arrow-select",
  "atoi",
- "base64",
+ "base64 0.23.1",
  "chrono",
  "half",
  "lexical-core",
- "num",
+ "num-traits",
  "ryu",
 ]
 
 [[package]]
 name = "arrow-csv"
-version = "56.0.0"
+version = "59.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "673fd2b5fb57a1754fdbfac425efd7cf54c947ac9950c1cce86b14e248f1c458"
+checksum = "25011b52b346407d497ef0030e12b45e4f2d0cc279efc09c4f3d09106db30e36"
 dependencies = [
  "arrow-array",
  "arrow-cast",
@@ -227,56 +232,61 @@ dependencies = [
 
 [[package]]
 name = "arrow-data"
-version = "56.0.0"
+version = "59.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97c22fe3da840039c69e9f61f81e78092ea36d57037b4900151f063615a2f6b4"
+checksum = "723fe4aeed7604e00b9883a465af4ff0a0e6c44c03e41a68c3d1cbc403e0e44d"
 dependencies = [
  "arrow-buffer",
  "arrow-schema",
  "half",
- "num",
+ "num-integer",
+ "num-traits",
 ]
 
 [[package]]
 name = "arrow-ipc"
-version = "56.0.0"
+version = "59.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "778de14c5a69aedb27359e3dd06dd5f9c481d5f6ee9fbae912dba332fd64636b"
+checksum = "149437b14371f5b9ec60f5ddc751483ae99d7a7072653c0075e5e469156eea7b"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
  "arrow-data",
  "arrow-schema",
+ "arrow-select",
  "flatbuffers",
 ]
 
 [[package]]
 name = "arrow-json"
-version = "56.0.0"
+version = "59.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3860db334fe7b19fcf81f6b56f8d9d95053f3839ffe443d56b5436f7a29a1794"
+checksum = "f18b9123ccfec418a663f821c9a034af339711678c11ffe00d3ec07da5ff9f7e"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
  "arrow-cast",
- "arrow-data",
+ "arrow-ord",
  "arrow-schema",
+ "arrow-select",
  "chrono",
  "half",
  "indexmap",
+ "itoa",
  "lexical-core",
  "memchr",
- "num",
- "serde",
+ "num-traits",
+ "ryu",
+ "serde_core",
  "serde_json",
  "simdutf8",
 ]
 
 [[package]]
 name = "arrow-ord"
-version = "56.0.0"
+version = "59.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "425fa0b42a39d3ff55160832e7c25553e7f012c3f187def3d70313e7a29ba5d9"
+checksum = "e6c08dff0686cf23ca4f562803f191ccbeb726dbae6309cd4b4aaf65e0f2c979"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -287,9 +297,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-pyarrow"
-version = "56.0.0"
+version = "59.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d944d8ae9b77230124e6570865b570416c33a5809f32c4136c679bbe774e45c9"
+checksum = "c196ecc25b3a8dcbc1d842f2619cee653dcfa2fb8b56a291bc0481c3cf5c3821"
 dependencies = [
  "arrow-array",
  "arrow-data",
@@ -299,9 +309,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-row"
-version = "56.0.0"
+version = "59.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df9c9423c9e71abd1b08a7f788fcd203ba2698ac8e72a1f236f1faa1a06a7414"
+checksum = "bbec439386df71ad570e6758a946111322b9e9dc8db83b5527321f0b4c9119c2"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -312,32 +322,32 @@ dependencies = [
 
 [[package]]
 name = "arrow-schema"
-version = "56.0.0"
+version = "59.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85fa1babc4a45fdc64a92175ef51ff00eba5ebbc0007962fecf8022ac1c6ce28"
+checksum = "e6fed2ca0d1eade57e811cbe73b98ad50cc08a1183e13b2d2aa43a7df593f40e"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags",
 ]
 
 [[package]]
 name = "arrow-select"
-version = "56.0.0"
+version = "59.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8854d15f1cf5005b4b358abeb60adea17091ff5bdd094dca5d3f73787d81170"
+checksum = "466b19cf75130b891dc1b23a84b343c714c62c64c9c62e365c76aa0ff90a53fb"
 dependencies = [
  "ahash 0.8.12",
  "arrow-array",
  "arrow-buffer",
  "arrow-data",
  "arrow-schema",
- "num",
+ "num-traits",
 ]
 
 [[package]]
 name = "arrow-string"
-version = "56.0.0"
+version = "59.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c477e8b89e1213d5927a2a84a72c384a9bf4dd0dbf15f9fd66d821aafd9e95e"
+checksum = "c838a25bb3691e919e0f617616ac51a4ff8517a952e29ca133cf0c22b2ce65b1"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -345,20 +355,20 @@ dependencies = [
  "arrow-schema",
  "arrow-select",
  "memchr",
- "num",
+ "num-traits",
  "regex",
  "regex-syntax",
 ]
 
 [[package]]
 name = "async-trait"
-version = "0.1.89"
+version = "0.1.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+checksum = "82f6aeea286b8eb4dd3431a1be1b59d290ace00f5bfd8e2a159bc2a05e2c1667"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -378,15 +388,21 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "autocfg"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "base64"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac07cdecf99051d9a5238b80f35af32cdeba5b336e55d957b318b50137e18da5"
 
 [[package]]
 name = "bit-set"
@@ -405,15 +421,9 @@ checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
 name = "bitflags"
-version = "1.3.2"
+version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
-
-[[package]]
-name = "bitflags"
-version = "2.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
+checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
 
 [[package]]
 name = "bitvec"
@@ -437,6 +447,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-buffer"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "borsh"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -457,14 +476,14 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "brotli"
-version = "8.0.2"
+version = "8.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bd8b9603c7aa97359dbd97ecf258968c95f3adddd6db2f7e7a5bef101c84560"
+checksum = "5cc91aac060a7a1e25823bdccbfb6af1875b88f17c6daac97894eed8207166b3"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
@@ -473,19 +492,29 @@ dependencies = [
 
 [[package]]
 name = "brotli-decompressor"
-version = "5.0.0"
+version = "5.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "874bb8112abecc98cbd6d81ea4fa7e94fb9449648c93cc89aa40c81c24d7de03"
+checksum = "3a32acac15fe1967bc3986b2a6347dffc965602354ea6f450ad07e8bfd253583"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
 ]
 
 [[package]]
-name = "bumpalo"
-version = "3.19.1"
+name = "bstr"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dd9dc738b7a8311c7ade152424974d8115f2cdad61e8dab8dac9f2362298510"
+checksum = "6bb31b46c14244e20ee9984b11bf5c992b91fb6939fea616e3512c8baecdbe5f"
+dependencies = [
+ "memchr",
+ "serde_core",
+]
+
+[[package]]
+name = "bumpalo"
+version = "3.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "bytecheck"
@@ -517,9 +546,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.11.0"
+version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b35204fbdc0b3f4446b89fc1ac2cf84a8a68971995d0bf2e925ec7cd960f9cb3"
+checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 
 [[package]]
 name = "cast"
@@ -529,9 +558,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.2.54"
+version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6354c81bbfd62d9cfa9cb3c773c2b7b2a3a482d569de977fd0e961f6e7c00583"
+checksum = "509591b7bcd67f4ef775afad7662703b4935daaa6ec0e5605cfb1090b32a2b6d"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -552,10 +581,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
 
 [[package]]
-name = "chrono"
-version = "0.4.43"
+name = "chacha20"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fac4744fb15ae8337dc853fee7fb3f4e48c0fbaa23d0afe49c447b4fab126118"
+checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.1",
+]
+
+[[package]]
+name = "chrono"
+version = "0.4.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
 dependencies = [
  "iana-time-zone",
  "num-traits",
@@ -591,18 +631,18 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.54"
+version = "4.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6e6ff9dcd79cff5cd969a17a545d79e84ab086e444102a591e288a8aa3ce394"
+checksum = "473c7e07f409a8d772161724aa8db6a765a2532a70f9667eeb7b49d3d02fbdca"
 dependencies = [
  "clap_builder",
 ]
 
 [[package]]
 name = "clap_builder"
-version = "4.5.54"
+version = "4.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa42cf4d2b7a41bc8f663a7cab4031ebafa1bf3875705bfaf8466dc60ab52c00"
+checksum = "7b48fea5a88e9ae728a2dcbedbfc0e730f7d60da42e1cb049a83c9fb8b789889"
 dependencies = [
  "anstyle",
  "clap_lex",
@@ -610,31 +650,33 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.7.7"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3e64b0cc0439b12df2fa678eae89a1c56a529fd067a9115f7827f1fffd22b32"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
-name = "concurrent-queue"
-version = "2.5.0"
+name = "cmov"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
-dependencies = [
- "crossbeam-utils",
-]
+checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
 
 [[package]]
 name = "console"
-version = "0.16.2"
+version = "0.16.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03e45a4a8926227e4197636ba97a9fc9b00477e9f4bd711395687c5f0734bec4"
+checksum = "4fe5f465a4f6fee88fad41b85d990f84c835335e85b5d9e6e63e0d06d28cba7c"
 dependencies = [
  "encode_unicode",
  "libc",
- "once_cell",
  "unicode-width",
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
 
 [[package]]
 name = "const-random"
@@ -658,9 +700,9 @@ dependencies = [
 
 [[package]]
 name = "core-foundation"
-version = "0.9.4"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -682,6 +724,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "crc"
 version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -692,9 +743,9 @@ dependencies = [
 
 [[package]]
 name = "crc-catalog"
-version = "2.4.0"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
+checksum = "217698eaf96b4a3f0bc4f3662aaa55bdf913cd54d7204591faa790070c6d0853"
 
 [[package]]
 name = "crc32fast"
@@ -707,9 +758,9 @@ dependencies = [
 
 [[package]]
 name = "criterion"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d883447757bb0ee46f233e9dc22eb84d93a9508c9b868687b274fc431d886bf"
+checksum = "950046b2aa2492f9a536f5f4f9a3de7b9e2476e575e05bd6c333371add4d98f3"
 dependencies = [
  "alloca",
  "anes",
@@ -732,9 +783,9 @@ dependencies = [
 
 [[package]]
 name = "criterion-plot"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed943f81ea2faa8dcecbbfa50164acf95d555afec96a27871663b300e387b2e4"
+checksum = "d8d80a2f4f5b554395e47b5d8305bc3d27813bacb73493eb1001e8f76dae29ea"
 dependencies = [
  "cast",
  "itertools",
@@ -742,9 +793,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-deque"
-version = "0.8.6"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+checksum = "5181e0de7b61eb03a81e347d6dd8797bae9da5146707b51077e2d71a54ec0ceb"
 dependencies = [
  "crossbeam-epoch",
  "crossbeam-utils",
@@ -752,27 +803,27 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]
 
 [[package]]
 name = "crossbeam-queue"
-version = "0.3.12"
+version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f58bbc28f91df819d0aa2a2c00cd19754769c2fad90579b3592b1c9ba7a3115"
+checksum = "803d13fb3b09d88be9f4dbc29062c66b19bf7170867ceb746d2a8689bf6c7a26"
 dependencies = [
  "crossbeam-utils",
 ]
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.21"
+version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+checksum = "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
 
 [[package]]
 name = "crunchy"
@@ -788,6 +839,15 @@ checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
  "typenum",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
+dependencies = [
+ "hybrid-array",
 ]
 
 [[package]]
@@ -812,25 +872,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "ctutils"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
+dependencies = [
+ "cmov",
+]
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer",
- "crypto-common",
- "subtle",
+ "block-buffer 0.10.4",
+ "crypto-common 0.1.7",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
+dependencies = [
+ "block-buffer 0.12.1",
+ "const-oid",
+ "crypto-common 0.2.2",
+ "ctutils",
 ]
 
 [[package]]
 name = "displaydoc"
-version = "0.2.5"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+checksum = "c6232dd377dcc64799954cbd3a9bb882e9cdc1308ccd87b1c098f1fb2eaf82a8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -841,9 +921,9 @@ checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
 
 [[package]]
 name = "either"
-version = "1.15.0"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+checksum = "9e5e8f6c15a24b9a3ee5efec809ccd006d3b30e8b3bb63c39af737c7f87daa1d"
 dependencies = [
  "serde",
 ]
@@ -863,7 +943,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -884,22 +964,20 @@ dependencies = [
 
 [[package]]
 name = "etcetera"
-version = "0.8.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "136d1b5283a1ab77bd9257427ffd09d8667ced0570b6f938942bc7568ed5b943"
+checksum = "de48cc4d1c1d97a20fd819def54b890cadde72ed3ad0c614822a0a433361be96"
 dependencies = [
  "cfg-if",
- "home",
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "event-listener"
-version = "5.4.1"
+version = "5.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
+checksum = "5a23add41df1562121a9393cb065eab5146a1242410f23a644851e90cfd669d2"
 dependencies = [
- "concurrent-queue",
  "parking",
  "pin-project-lite",
 ]
@@ -912,26 +990,25 @@ checksum = "4443176a9f2c162692bd3d352d745ef9413eec5782a80d8fd6f8a1ac692a07f7"
 
 [[package]]
 name = "fastrand"
-version = "2.3.0"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
 
 [[package]]
 name = "filetime"
-version = "0.2.27"
+version = "0.2.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f98844151eee8917efc50bd9e8318cb963ae8b297431495d3f758616ea5c57db"
+checksum = "5c287a33c7f0a620c38e641e7f60827713987b3c0f26e8ddc9462cc69cf75759"
 dependencies = [
  "cfg-if",
  "libc",
- "libredox",
 ]
 
 [[package]]
 name = "find-msvc-tools"
-version = "0.1.8"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8591b0bcc8a98a64310a2fae1bb3e9b8564dd10e381e6e28010fde8e8e8568db"
+checksum = "d45db016d36b838f563236e9193d0ee6ce38f3f68b6c94e914b4929c96bbb890"
 
 [[package]]
 name = "flatbuffers"
@@ -939,15 +1016,15 @@ version = "25.12.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "35f6839d7b3b98adde531effaf34f0c2badc6f4735d26fe74709d8e513a96ef3"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags",
  "rustc_version",
 ]
 
 [[package]]
 name = "flate2"
-version = "1.1.8"
+version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b375d6465b98090a5f25b1c7703f3859783755aa9a80433b36e0379a3ec2f369"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
@@ -962,9 +1039,9 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "foldhash"
-version = "0.1.5"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "foreign-types"
@@ -998,9 +1075,9 @@ checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "futures"
-version = "0.3.31"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
+checksum = "9a31d2a3fbaaeb2af2368bbdd904aa8e812d3c04a1ee10d3171f52d556e5d0a3"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1013,9 +1090,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.31"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
+checksum = "b1f9e3d69d39e4862ffed03ed071a76f9a13ba1d9109d355b0f0aa6b15e393c4"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -1023,15 +1100,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.31"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
+checksum = "92d699e522242e69e3003b94ecc1f960f3a5e015aa7c5d7486e65ad01dd94f5e"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.31"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
+checksum = "031b47cf1a3c6cc8bc2fc76cd437f521619387907d469316e7c0bc278f1f5432"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -1046,49 +1123,49 @@ checksum = "1d930c203dd0b6ff06e0201a4a2fe9149b43c684fd4420555b26d21b1a02956f"
 dependencies = [
  "futures-core",
  "lock_api",
- "parking_lot 0.12.5",
+ "parking_lot",
 ]
 
 [[package]]
 name = "futures-io"
-version = "0.3.31"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
+checksum = "53c0fa8157de1303bfffdaa1cc2a673bfffb60102f76b0ef4441659124373fed"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.31"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
+checksum = "9fb9654ba8355388abeb8dcb4fc62f511300867002afc858860463bdd9fe0c44"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 3.0.3",
 ]
 
 [[package]]
 name = "futures-sink"
-version = "0.3.31"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
+checksum = "1944426bf7d03f1d14f708785e4b33efd750b36d48a157b836b3efc15ede8e1d"
 
 [[package]]
 name = "futures-task"
-version = "0.3.31"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
+checksum = "cd417de3d1d015fc3bfd2b1ea46dfc7bab72ef86f1cc7cc9c78e728b34a6d1fd"
 
 [[package]]
 name = "futures-timer"
-version = "3.0.3"
+version = "3.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f288b0a4f20f9a56b5d1da57e2227c661b7b16168e2f72365f57b63326e29b24"
+checksum = "af43fadb8a98512d547e37b4e92e0ced13e205c061b87b4623eff01d918d6968"
 
 [[package]]
 name = "futures-util"
-version = "0.3.31"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
+checksum = "0d50a92467f8ba5dd6e3ee5d4bd04d73ab2e4e1c44474a0674821dfce14b79bc"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1098,7 +1175,6 @@ dependencies = [
  "futures-task",
  "memchr",
  "pin-project-lite",
- "pin-utils",
  "slab",
 ]
 
@@ -1133,15 +1209,46 @@ checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi",
+ "r-efi 5.3.0",
  "wasip2",
 ]
 
 [[package]]
-name = "glob"
-version = "0.3.3"
+name = "getrandom"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 6.0.0",
+ "rand_core 0.10.1",
+]
+
+[[package]]
+name = "glob"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4eba85ea1d0a966a983acd07deee566e67395d2d96b6fb39e62b5a833f1eb0b"
+
+[[package]]
+name = "h2"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http",
+ "indexmap",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
 
 [[package]]
 name = "half"
@@ -1166,9 +1273,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.15.5"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 dependencies = [
  "allocator-api2",
  "equivalent",
@@ -1177,17 +1284,17 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.16.1"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "hashlink"
-version = "0.10.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
+checksum = "824e001ac4f3012dd16a264bec811403a67ca9deb6c102fc5049b32c4574b35f"
 dependencies = [
- "hashbrown 0.15.5",
+ "hashbrown 0.16.1",
 ]
 
 [[package]]
@@ -1204,36 +1311,27 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hkdf"
-version = "0.12.4"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
+checksum = "4aaa26c720c68b866f2c96ef5c1264b3e6f473fe5d4ce61cd44bbe913e553018"
 dependencies = [
  "hmac",
 ]
 
 [[package]]
 name = "hmac"
-version = "0.12.1"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
 dependencies = [
- "digest",
-]
-
-[[package]]
-name = "home"
-version = "0.5.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
-dependencies = [
- "windows-sys 0.61.2",
+ "digest 0.11.3",
 ]
 
 [[package]]
 name = "http"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
+checksum = "918d3568bebf352712bc2ef3d46a8bcf1a75b373be6539de198e9105cbbf9ce0"
 dependencies = [
  "bytes",
  "itoa",
@@ -1241,9 +1339,9 @@ dependencies = [
 
 [[package]]
 name = "http-body"
-version = "1.0.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
+checksum = "ca2a8f2913ee65f60facd6a5905613afaa448497a0230cc41ce022d93290bc2c"
 dependencies = [
  "bytes",
  "http",
@@ -1251,9 +1349,9 @@ dependencies = [
 
 [[package]]
 name = "http-body-util"
-version = "0.1.3"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
+checksum = "23169fe34a5fbcdd3f3862e78fb9b6fccd5f02a6dc6f732547005d45631ce71c"
 dependencies = [
  "bytes",
  "futures-core",
@@ -1269,24 +1367,48 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
-name = "hyper"
-version = "1.8.1"
+name = "hybrid-array"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ab2d4f250c3d7b1c9fcdff1cece94ea4e2dfbec68614f7b87cb205f24ca9d11"
+checksum = "707114b52a152fa7bdb290cd7cd5912d9467273b6d74e21b8d81aca1f8533f6b"
+dependencies = [
+ "typenum",
+]
+
+[[package]]
+name = "hyper"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d22053281f852e11534f5198498373cbb59295120a20771d90f7ed1897490a72"
 dependencies = [
  "atomic-waker",
  "bytes",
  "futures-channel",
  "futures-core",
+ "h2",
  "http",
  "http-body",
  "httparse",
  "itoa",
  "pin-project-lite",
- "pin-utils",
  "smallvec",
  "tokio",
  "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.27.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
+dependencies = [
+ "http",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
 ]
 
 [[package]]
@@ -1307,14 +1429,13 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.19"
+version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "727805d60e7938b76b826a6ef209eb70eaa1812794f9424d4a4e2d740662df5f"
+checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures-channel",
- "futures-core",
  "futures-util",
  "http",
  "http-body",
@@ -1331,9 +1452,9 @@ dependencies = [
 
 [[package]]
 name = "iana-time-zone"
-version = "0.1.64"
+version = "0.1.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33e57f83510bb73707521ebaffa789ec8caf86f9657cad665b092b581d40e9fb"
+checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
 dependencies = [
  "android_system_properties",
  "core-foundation-sys",
@@ -1355,12 +1476,13 @@ dependencies = [
 
 [[package]]
 name = "icu_collections"
-version = "2.1.1"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c6b649701667bbe825c3b7e6388cb521c23d88644678e83c0c4d0a621a34b43"
+checksum = "fa68d21081c4a05d5a901a1c62add574c77048b6a1c67be3b50ce0b60d4ca513"
 dependencies = [
  "displaydoc",
  "potential_utf",
+ "utf8_iter",
  "yoke",
  "zerofrom",
  "zerovec",
@@ -1368,9 +1490,9 @@ dependencies = [
 
 [[package]]
 name = "icu_locale_core"
-version = "2.1.1"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edba7861004dd3714265b4db54a3c390e880ab658fec5f7db895fae2046b5bb6"
+checksum = "d56e28588da92eee5c3201a6eff33fabdd49b62269c8938d4ff050ce4d900deb"
 dependencies = [
  "displaydoc",
  "litemap",
@@ -1381,9 +1503,9 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer"
-version = "2.1.1"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f6c8828b67bf8908d82127b2054ea1b4427ff0230ee9141c54251934ab1b599"
+checksum = "12f9cf5f235641ed274641dd81c3f28d870e276763d0797aeeab72317b1c646f"
 dependencies = [
  "icu_collections",
  "icu_normalizer_data",
@@ -1395,16 +1517,17 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer_data"
-version = "2.1.1"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7aedcccd01fc5fe81e6b489c15b247b8b0690feb23304303a9e560f37efc560a"
+checksum = "1563da1ed3e0b3bf3d74c9b85917ac9c56464d2f57242270c09c9e752f8021a0"
 
 [[package]]
 name = "icu_properties"
-version = "2.1.2"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "020bfc02fe870ec3a66d93e677ccca0562506e5872c650f893269e08615d74ec"
+checksum = "7e7ca276ad3145661a65914e6daf131ca5120cd3dcee8f8f3214b8875184a148"
 dependencies = [
+ "displaydoc",
  "icu_collections",
  "icu_locale_core",
  "icu_properties_data",
@@ -1415,15 +1538,15 @@ dependencies = [
 
 [[package]]
 name = "icu_properties_data"
-version = "2.1.2"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "616c294cf8d725c6afcd8f55abc17c56464ef6211f9ed59cccffe534129c77af"
+checksum = "e590f038c1464a96894fd6d10127e90a8be4509f56ff7ecef851b15cee0b7caa"
 
 [[package]]
 name = "icu_provider"
-version = "2.1.1"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85962cf0ce02e1e0a629cc34e7ca3e373ce20dda4c4d7294bbd0bf1fdb59e614"
+checksum = "92a7ed671a6aad807a8651a2e1782a6598fda9ce5185dd8158549e95a91c6428"
 dependencies = [
  "displaydoc",
  "icu_locale_core",
@@ -1447,9 +1570,9 @@ dependencies = [
 
 [[package]]
 name = "idna_adapter"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
+checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
@@ -1457,56 +1580,19 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.13.0"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
 ]
-
-[[package]]
-name = "indoc"
-version = "2.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79cf5c93f93228cf8efb3ba362535fb11199ac548a09ce117c9b1adc3030d706"
-dependencies = [
- "rustversion",
-]
-
-[[package]]
-name = "instant"
-version = "0.1.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222"
-dependencies = [
- "cfg-if",
- "js-sys",
- "wasm-bindgen",
- "web-sys",
-]
-
-[[package]]
-name = "integer-encoding"
-version = "3.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bb03732005da905c88227371639bf1ad885cc712789c011c31c5fb3ab3ccf02"
 
 [[package]]
 name = "ipnet"
-version = "2.11.0"
+version = "2.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
-
-[[package]]
-name = "iri-string"
-version = "0.7.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c91338f0783edbd6195decb37bae672fd3b165faffb89bf7b9e6942f8b1a731a"
-dependencies = [
- "memchr",
- "serde",
-]
+checksum = "6a756c3fac73139e83f14c2d742155dd2b78d3ee56597b419a0579b7bdd6dd78"
 
 [[package]]
 name = "itertools"
@@ -1519,27 +1605,28 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jobserver"
-version = "0.1.34"
+version = "0.1.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+checksum = "1c00acbd29eabad4a2392fa0e921c874934dbbf4194312ad20f04a0ed67a3cb3"
 dependencies = [
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "libc",
 ]
 
 [[package]]
 name = "js-sys"
-version = "0.3.85"
+version = "0.3.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c942ebf8e95485ca0d52d97da7c5a2c387d0e7f0ba4c35e93bfcaee045955b3"
+checksum = "0e0c1080212aad755ea003d18543e8768dd432c48819efd73a7bf1e39b7a5a3a"
 dependencies = [
- "once_cell",
+ "cfg-if",
+ "futures-util",
  "wasm-bindgen",
 ]
 
@@ -1602,9 +1689,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.180"
+version = "0.2.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcc35a38544a891a5f7c865aca548a982ccb3b8650a5b06d0fd33a10283c56fc"
+checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 
 [[package]]
 name = "libm"
@@ -1614,26 +1701,24 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libredox"
-version = "0.1.12"
+version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d0b95e02c851351f877147b7deea7b1afb1df71b63aa5f8270716e0c5720616"
+checksum = "28d0a00925a9f930d679b6789b721e3a7f9ed110f41b86d2497caa780c3a070a"
 dependencies = [
- "bitflags 2.10.0",
  "libc",
- "redox_syscall 0.7.0",
 ]
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.11.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litemap"
-version = "0.8.1"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
+checksum = "47d9d19d1d6efa0109d2f65ff4c85cddd50bd572e5a00127ab10987290bcefae"
 
 [[package]]
 name = "lock_api"
@@ -1646,15 +1731,15 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.29"
+version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
 name = "lz4_flex"
-version = "0.11.5"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08ab2867e3eeeca90e844d1940eab391c9dc5228783db2ed999acbc0a9ed375a"
+checksum = "ecbdfe44b1bd960b68170b417450a628c43f7cf56bb3c5317e61cb230ee7f226"
 dependencies = [
  "twox-hash",
 ]
@@ -1667,28 +1752,19 @@ checksum = "2f926ade0c4e170215ae43342bf13b9310a437609c81f29f86c5df6657582ef9"
 
 [[package]]
 name = "md-5"
-version = "0.10.6"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
+checksum = "69b6441f590336821bb897fb28fc622898ccceb1d6cea3fde5ea86b090c4de98"
 dependencies = [
  "cfg-if",
- "digest",
+ "digest 0.11.3",
 ]
 
 [[package]]
 name = "memchr"
-version = "2.7.6"
+version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
-
-[[package]]
-name = "memoffset"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
-dependencies = [
- "autocfg",
-]
+checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "miniz_oxide"
@@ -1702,9 +1778,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.1.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
+checksum = "30d65c71f1ce40ab09135ce117d742b9f8a19ff91a41a8b57ed50bc2de59c427"
 dependencies = [
  "libc",
  "wasi 0.11.1+wasi-snapshot-preview1",
@@ -1713,9 +1789,9 @@ dependencies = [
 
 [[package]]
 name = "native-tls"
-version = "0.2.14"
+version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87de3442987e9dbec73158d5c715e7ad9072fda936bb03d19d7fa10e00520f0e"
+checksum = "465500e14ea162429d264d44189adc38b199b62b1c21eea9f69e4b73cb03bbf2"
 dependencies = [
  "libc",
  "log",
@@ -1729,24 +1805,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "num"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23"
-dependencies = [
- "num-bigint",
- "num-complex",
- "num-integer",
- "num-iter",
- "num-rational",
- "num-traits",
-]
-
-[[package]]
 name = "num-bigint"
-version = "0.4.6"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+checksum = "93e7820bc0a80a0238e650327316f929ba18d5be054b647490a3a6a339f3e7c0"
 dependencies = [
  "num-integer",
  "num-traits",
@@ -1762,43 +1824,11 @@ dependencies = [
 ]
 
 [[package]]
-name = "num-format"
-version = "0.4.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a652d9771a63711fd3c3deb670acfbe5c30a4072e664d7a3bf5a9e1056ac72c3"
-dependencies = [
- "arrayvec",
- "itoa",
-]
-
-[[package]]
 name = "num-integer"
-version = "0.1.46"
+version = "0.1.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+checksum = "7ce2d95d4b3734dc35aa2f45e1aa22cd416814592a4f9d9205e11affd5b8e10b"
 dependencies = [
- "num-traits",
-]
-
-[[package]]
-name = "num-iter"
-version = "0.1.45"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
-dependencies = [
- "autocfg",
- "num-integer",
- "num-traits",
-]
-
-[[package]]
-name = "num-rational"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
-dependencies = [
- "num-bigint",
- "num-integer",
  "num-traits",
 ]
 
@@ -1813,10 +1843,28 @@ dependencies = [
 ]
 
 [[package]]
-name = "once_cell"
-version = "1.21.3"
+name = "objc2-core-foundation"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
+name = "objc2-system-configuration"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7216bd11cbda54ccabcab84d523dc93b858ec75ecfb3a7d89513fa22464da396"
+dependencies = [
+ "objc2-core-foundation",
+]
+
+[[package]]
+name = "once_cell"
+version = "1.21.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "oorandom"
@@ -1826,15 +1874,14 @@ checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "openssl"
-version = "0.10.75"
+version = "0.10.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08838db121398ad17ab8531ce9de97b244589089e290a384c900cb9ff7434328"
+checksum = "77823a27f0babb03091cb9ed9ef80af3b39dbc82f97e8fa530374b7dafd87a45"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags",
  "cfg-if",
  "foreign-types",
  "libc",
- "once_cell",
  "openssl-macros",
  "openssl-sys",
 ]
@@ -1847,34 +1894,25 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "openssl-probe"
-version = "0.1.6"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.111"
+version = "0.9.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82cab2d520aa75e3c58898289429321eb788c3106963d0dc886ec7a5f4adc321"
+checksum = "b47e7e6bb2c38cd930d25a23b40fa52e068c10e85f3e03a7f5ba5aaca5713695"
 dependencies = [
  "cc",
  "libc",
  "pkg-config",
  "vcpkg",
-]
-
-[[package]]
-name = "ordered-float"
-version = "2.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68f19d67e5a2795c94e73e0bb1cc1a7edeb2e28efd39e2e1c9b7a40c1108b11c"
-dependencies = [
- "num-traits",
 ]
 
 [[package]]
@@ -1895,37 +1933,12 @@ checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
 
 [[package]]
 name = "parking_lot"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d17b78036a60663b797adeaee46f5c9dfebb86948d1255007a1d6be0271ff99"
-dependencies = [
- "instant",
- "lock_api",
- "parking_lot_core 0.8.6",
-]
-
-[[package]]
-name = "parking_lot"
 version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
 dependencies = [
  "lock_api",
- "parking_lot_core 0.9.12",
-]
-
-[[package]]
-name = "parking_lot_core"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60a2cfe6f0ad2bfc16aefa463b497d5c7a5ecd44a23efa72aa342d90177356dc"
-dependencies = [
- "cfg-if",
- "instant",
- "libc",
- "redox_syscall 0.2.16",
- "smallvec",
- "winapi",
+ "parking_lot_core",
 ]
 
 [[package]]
@@ -1936,49 +1949,41 @@ checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall 0.5.18",
+ "redox_syscall",
  "smallvec",
  "windows-link",
 ]
 
 [[package]]
 name = "parquet"
-version = "56.0.0"
+version = "59.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7288a07ed5d25939a90f9cb1ca5afa6855faa08ec7700613511ae64bdb0620c"
+checksum = "7065842956a20c2a536924ce8e4d9955f7422451511b9eb7500d7bfe5077e59c"
 dependencies = [
  "ahash 0.8.12",
  "arrow-array",
  "arrow-buffer",
- "arrow-cast",
  "arrow-data",
  "arrow-ipc",
  "arrow-schema",
  "arrow-select",
- "base64",
+ "base64 0.23.1",
  "brotli",
  "bytes",
  "chrono",
  "flate2",
  "half",
- "hashbrown 0.15.5",
+ "hashbrown 0.17.1",
  "lz4_flex",
- "num",
  "num-bigint",
- "paste",
+ "num-integer",
+ "num-traits",
  "seq-macro",
  "simdutf8",
  "snap",
- "thrift",
  "twox-hash",
  "zstd",
 ]
-
-[[package]]
-name = "paste"
-version = "1.0.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "percent-encoding"
@@ -1990,7 +1995,6 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 name = "pgpq"
 version = "0.11.1"
 dependencies = [
- "anyhow",
  "arrow",
  "arrow-array",
  "arrow-ipc",
@@ -2008,7 +2012,7 @@ dependencies = [
  "rstest",
  "rust_decimal",
  "similar",
- "thiserror 1.0.69",
+ "thiserror",
  "ureq",
 ]
 
@@ -2033,9 +2037,9 @@ dependencies = [
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pin-utils"
@@ -2045,9 +2049,9 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkg-config"
-version = "0.3.32"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+checksum = "f6b464fbc74e149a392436b17d523f769e057cb6877f6a5c4618bc6f11800548"
 
 [[package]]
 name = "plotters"
@@ -2079,15 +2083,15 @@ dependencies = [
 
 [[package]]
 name = "portable-atomic"
-version = "1.13.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f89776e4d69bb58bc6993e99ffa1d11f228b839984854c7daeb5d37f87cbe950"
+checksum = "05c8b63e8d9609db387f0324918f81d68fe27748f084ef092fb35954d0539a85"
 
 [[package]]
 name = "postgres"
-version = "0.19.12"
+version = "0.19.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7c48ece1c6cda0db61b058c1721378da76855140e9214339fa1317decacb176"
+checksum = "33ad20e0aa0b24f5a394eab4f78c781d248982b22b25cecc7e3aa46a681605bd"
 dependencies = [
  "bytes",
  "fallible-iterator",
@@ -2099,27 +2103,27 @@ dependencies = [
 
 [[package]]
 name = "postgres-protocol"
-version = "0.6.10"
+version = "0.6.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ee9dd5fe15055d2b6806f4736aa0c9637217074e224bbec46d4041b91bb9491"
+checksum = "08808e3c483c46e999108051c78334f473d5adb59d78bb80a1268c7e6aa6c514"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "byteorder",
  "bytes",
  "fallible-iterator",
  "hmac",
  "md-5",
  "memchr",
- "rand 0.9.2",
- "sha2",
+ "rand 0.10.2",
+ "sha2 0.11.0",
  "stringprep",
 ]
 
 [[package]]
 name = "postgres-types"
-version = "0.2.12"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54b858f82211e84682fecd373f68e1ceae642d8d751a1ebd13f33de6257b3e20"
+checksum = "851ca9db4932932d69f3ea811b1abe63087a0f740a47692619dd40d4899b68be"
 dependencies = [
  "bytes",
  "chrono",
@@ -2129,15 +2133,14 @@ dependencies = [
 
 [[package]]
 name = "postgresql_archive"
-version = "0.20.0"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e80b519badc77389e9bb48944da8b639eaddc0ab9bb0e921be233c11348f3655"
+checksum = "274b4eeb875f1196cc577a69b17c3018a3b189d4017122648b1465066b8b08c1"
 dependencies = [
  "async-trait",
  "flate2",
  "futures-util",
  "hex",
- "num-format",
  "regex-lite",
  "reqwest",
  "reqwest-middleware",
@@ -2146,41 +2149,38 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "tar",
  "target-triple",
  "tempfile",
- "thiserror 2.0.18",
  "tracing",
  "url",
 ]
 
 [[package]]
 name = "postgresql_commands"
-version = "0.20.0"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20698f9f0fddfa20bb0f8db60c47c7c1996b781c8e4bc2d09182d6cab66da25c"
+checksum = "66e1f10f6246287203d57775b1be7a9050c6d3f45c9021853eda3cfee3bf95e9"
 dependencies = [
- "thiserror 2.0.18",
  "tokio",
  "tracing",
 ]
 
 [[package]]
 name = "postgresql_embedded"
-version = "0.20.0"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c73524453412018db32b4929cc0b58ecb2d04cff679e9d397ab32880fbe7a0ca"
+checksum = "87673b35bc80ddcc8eb54072d90290c6d2e3777493fd2d0de46cf2e0d6677fe5"
 dependencies = [
  "anyhow",
  "postgresql_archive",
  "postgresql_commands",
- "rand 0.9.2",
+ "rand 0.10.2",
  "semver",
  "sqlx",
  "target-triple",
  "tempfile",
- "thiserror 2.0.18",
  "tokio",
  "tracing",
  "url",
@@ -2188,9 +2188,9 @@ dependencies = [
 
 [[package]]
 name = "potential_utf"
-version = "0.1.4"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
+checksum = "d83eb9bc6d8e5cf568e7a1101d60ee05e81ed50ea106026f3d18deeb046d7661"
 dependencies = [
  "zerovec",
 ]
@@ -2206,18 +2206,18 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-crate"
-version = "3.4.0"
+version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "219cb19e96be00ab2e37d6e299658a0cfa83e52429179969b0f0121b4ac46983"
+checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
 dependencies = [
  "toml_edit",
 ]
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.106"
+version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
+checksum = "985e7ec9bb745e6ce6535b544d84d6cd6f7ad8bd711c398938ae983b91a766d9"
 dependencies = [
  "unicode-ident",
 ]
@@ -2230,9 +2230,9 @@ checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
 dependencies = [
  "bit-set",
  "bit-vec",
- "bitflags 2.10.0",
+ "bitflags",
  "num-traits",
- "rand 0.9.2",
+ "rand 0.9.5",
  "rand_chacha 0.9.0",
  "rand_xorshift",
  "regex-syntax",
@@ -2263,36 +2263,32 @@ dependencies = [
 
 [[package]]
 name = "pyo3"
-version = "0.25.1"
+version = "0.29.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8970a78afe0628a3e3430376fc5fd76b6b45c4d43360ffd6cdd40bdde72b682a"
+checksum = "4688ddedf473e32662b9b067670129a8afb8c18e351482c70d62ba4a88171e8b"
 dependencies = [
- "indoc",
  "libc",
- "memoffset",
  "once_cell",
  "portable-atomic",
  "pyo3-build-config",
  "pyo3-ffi",
  "pyo3-macros",
- "unindent",
 ]
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.25.1"
+version = "0.29.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "458eb0c55e7ece017adeba38f2248ff3ac615e53660d7c71a238d7d2a01c7598"
+checksum = "f41027e41b4bd03f6e60f9f417fe24a6341a6bb744edd62b6f709f2a52ea30e9"
 dependencies = [
- "once_cell",
  "target-lexicon",
 ]
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.25.1"
+version = "0.29.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7114fe5457c61b276ab77c5055f206295b812608083644a5c5b2640c3102565c"
+checksum = "e591a95526fead067432c3b3a33fc74770b87b1e04e73671090d9c2055a2b327"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -2300,27 +2296,26 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.25.1"
+version = "0.29.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8725c0a622b374d6cb051d11a0983786448f7785336139c3c94f5aa6bef7e50"
+checksum = "73225868fc1cd84eef2c3c230ddb91273bf1de46aeb8a4248da76d32a0924a1c"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.25.1"
+version = "0.29.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4109984c22491085343c05b0dbc54ddc405c3cf7b4374fc533f5c3313a572ccc"
+checksum = "571575aa3749fa6216757dd47d2a3e7ef360f329a40f0666a9fbd14889024952"
 dependencies = [
  "heck",
  "proc-macro2",
- "pyo3-build-config",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2331,9 +2326,9 @@ checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quote"
-version = "1.0.44"
+version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21b2ebcf727b7760c461f091f9f0f539b77b8e87f2fd88131e7f1b433b3cece4"
+checksum = "1fbf4db142a473a8d80c26bbf18454ed458bf8d26c8219c331daecfdbd079001"
 dependencies = [
  "proc-macro2",
 ]
@@ -2345,6 +2340,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
 name = "radium"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2352,9 +2353,9 @@ checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "22f6172bdec972074665ed81ed53b71da00bfc44b65a753cfde883ec4c702a1a"
 dependencies = [
  "libc",
  "rand_chacha 0.3.1",
@@ -2363,12 +2364,23 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "b9ef1d0d795eb7d84685bca4f72f3649f064e6641543d3a8c415898726a57b41"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.3",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -2410,6 +2422,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
 name = "rand_xorshift"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2420,9 +2438,9 @@ dependencies = [
 
 [[package]]
 name = "rayon"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
 dependencies = [
  "either",
  "rayon-core",
@@ -2440,36 +2458,18 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.2.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
-dependencies = [
- "bitflags 1.3.2",
-]
-
-[[package]]
-name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.10.0",
-]
-
-[[package]]
-name = "redox_syscall"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49f3fe0889e69e2ae9e41f4d6c4c0181701d00e4697b356fb1f74173a5e0ee27"
-dependencies = [
- "bitflags 2.10.0",
+ "bitflags",
 ]
 
 [[package]]
 name = "regex"
-version = "1.12.2"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843bc0191f75f3e22651ae5f1e72939ab2f72a4bc30fa80a066bd66edefc24d4"
+checksum = "f020237b6c8eed93db2e2cb53c00c60a8e1bc73da7d073199a1180401450218d"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -2479,9 +2479,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.13"
+version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5276caf25ac86c8d810222b3dbb938e512c55c6831a10f3e6ed1c93b84041f1c"
+checksum = "ad8553b9b26413251cbf30e620595c7a41b3887f03da04579c0e6b0d6a06b4b2"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -2490,15 +2490,15 @@ dependencies = [
 
 [[package]]
 name = "regex-lite"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d942b98df5e658f56f20d592c7f868833fe38115e65c33003d8cd224b0155da"
+checksum = "cab834c73d247e67f4fae452806d17d3c7501756d98c8808d7c9c7aa7d18f973"
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.8"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
+checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "relative-path"
@@ -2517,18 +2517,20 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.12.28"
+version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures-core",
  "futures-util",
+ "h2",
  "http",
  "http-body",
  "http-body-util",
  "hyper",
+ "hyper-rustls",
  "hyper-tls",
  "hyper-util",
  "js-sys",
@@ -2556,24 +2558,24 @@ dependencies = [
 
 [[package]]
 name = "reqwest-middleware"
-version = "0.4.2"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57f17d28a6e6acfe1733fe24bcd30774d13bffa4b8a22535b4c8c98423088d4e"
+checksum = "07bc3f1384cffa4f274dad2d4ddd73aed32fed8f786d96c6be8aa4e5fd3c3b58"
 dependencies = [
  "anyhow",
  "async-trait",
  "http",
  "reqwest",
  "serde",
- "thiserror 1.0.69",
+ "thiserror",
  "tower-service",
 ]
 
 [[package]]
 name = "reqwest-retry"
-version = "0.7.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29c73e4195a6bfbcb174b790d9b3407ab90646976c55de58a6515da25d851178"
+checksum = "fe2412db2af7d2268e7a5406be0431f37d9eb67ff390f35b395716f5f06c2eaa"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2581,21 +2583,20 @@ dependencies = [
  "getrandom 0.2.17",
  "http",
  "hyper",
- "parking_lot 0.11.2",
  "reqwest",
  "reqwest-middleware",
  "retry-policies",
- "thiserror 1.0.69",
+ "thiserror",
  "tokio",
  "tracing",
- "wasm-timer",
+ "wasmtimer",
 ]
 
 [[package]]
 name = "reqwest-tracing"
-version = "0.5.8"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d70ea85f131b2ee9874f0b160ac5976f8af75f3c9badfe0d955880257d10bd83"
+checksum = "b5e5af0cd6fc3d3c8f703d597af70b6e4e62432c63157b49419fa1ffaf481702"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2609,11 +2610,11 @@ dependencies = [
 
 [[package]]
 name = "retry-policies"
-version = "0.4.0"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5875471e6cab2871bc150ecb8c727db5113c9338cc3354dc5ee3425b6aa40a1c"
+checksum = "dc05fbf560421a0357a750cbe78c7ca19d4923918490daabba313d5dbc871e47"
 dependencies = [
- "rand 0.8.5",
+ "rand 0.10.2",
 ]
 
 [[package]]
@@ -2684,7 +2685,7 @@ dependencies = [
  "regex",
  "relative-path",
  "rustc_version",
- "syn 2.0.114",
+ "syn 2.0.119",
  "unicode-ident",
 ]
 
@@ -2699,7 +2700,7 @@ dependencies = [
  "bytes",
  "num-traits",
  "postgres-types",
- "rand 0.8.5",
+ "rand 0.8.7",
  "rkyv",
  "serde",
  "serde_json",
@@ -2717,11 +2718,11 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "1.1.3"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "146c9e247ccc180c1f61615433868c99f3de3ae256a30a43b49f67c2d9171f34"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -2730,9 +2731,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.36"
+version = "0.23.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c665f33d38cea657d9614f766881e4d510e0eda4239891eea56b4cadcf01801b"
+checksum = "0283386ce02abc0151e1761d08802dfe86c173b0b494af5cbc086574e453da06"
 dependencies = [
  "log",
  "once_cell",
@@ -2745,18 +2746,18 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.14.0"
+version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
+checksum = "2f4925028c7eb5d1fcdaf196971378ed9d2c1c4efc7dc5d011256f76c99c0a96"
 dependencies = [
  "zeroize",
 ]
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.9"
+version = "0.103.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53"
+checksum = "0527518605e68109d875e248ea259b6758801cf165e4b2c2733ae3b51f12535a"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -2765,9 +2766,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.22"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
 
 [[package]]
 name = "rusty-fork"
@@ -2783,9 +2784,9 @@ dependencies = [
 
 [[package]]
 name = "ryu"
-version = "1.0.22"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a50f4cf475b65d88e057964e0e9bb1f0aa9bbb2036dc65c64596b42932536984"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "same-file"
@@ -2798,9 +2799,9 @@ dependencies = [
 
 [[package]]
 name = "schannel"
-version = "0.1.28"
+version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "891d81b926048e76efe18581bf793546b4c0eaf8448d72be8de2bbee5fd166e1"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
 dependencies = [
  "windows-sys 0.61.2",
 ]
@@ -2819,11 +2820,11 @@ checksum = "1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b"
 
 [[package]]
 name = "security-framework"
-version = "2.11.1"
+version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags",
  "core-foundation",
  "core-foundation-sys",
  "libc",
@@ -2832,9 +2833,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.15.0"
+version = "2.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc1f0cbffaac4852523ce30d8bd3c5cdc873501d96ff467ca09b6767bb8cd5c0"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -2842,9 +2843,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.27"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "seq-macro"
@@ -2854,9 +2855,9 @@ checksum = "1bc711410fbe7399f390ca1c3b60ad0f53f80e95c5eb935e52268a0e2cd49acc"
 
 [[package]]
 name = "serde"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+checksum = "4148590afebada386688f18773da617792bf2ef03ffc1e4cbd2b1d45b023e0ba"
 dependencies = [
  "serde_core",
  "serde_derive",
@@ -2864,29 +2865,29 @@ dependencies = [
 
 [[package]]
 name = "serde_core"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+checksum = "67dca2c9c51e58a4791a4b1ed58308b39c64224d349a935ab5039aa360942a48"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 3.0.3",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.149"
+version = "1.0.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+checksum = "c841b55ecdae098c80dcae9cf767f6f8a0c2cdb3416bbef72181df4d0fe73f14"
 dependencies = [
  "itoa",
  "memchr",
@@ -2914,15 +2915,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
- "digest",
+ "cpufeatures 0.2.17",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
 ]
 
 [[package]]
 name = "shlex"
-version = "1.3.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "signal-hook-registry"
@@ -2936,9 +2948,9 @@ dependencies = [
 
 [[package]]
 name = "simd-adler32"
-version = "0.3.8"
+version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
+checksum = "3a219298ac11a56ea9a6d2120044824d6f01aeb034955e7af7bc16858527deea"
 
 [[package]]
 name = "simdutf8"
@@ -2948,52 +2960,55 @@ checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
 name = "similar"
-version = "2.7.0"
+version = "3.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
+checksum = "85ee016af5d736b69fc89e19254540fa4b5f5492853fb5503920f084011c78b6"
+dependencies = [
+ "bstr",
+]
 
 [[package]]
 name = "siphasher"
-version = "1.0.1"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56199f7ddabf13fe5074ce809e7d3f42b42ae711800501b5b16ea82ad029c39d"
+checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
 
 [[package]]
 name = "slab"
-version = "0.4.11"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a2ae44ef20feb57a68b23d846850f861394c2e02dc425a50098ae8c90267589"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smallvec"
-version = "1.15.1"
+version = "1.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "snap"
-version = "1.1.1"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b6b67fb9a61334225b5b790716f609cd58395f895b3fe8b328786812a40bc3b"
+checksum = "199905e6153d6405f9728fe44daace35f8f837bbf830bb6e85fbd5828709a886"
 
 [[package]]
 name = "socket2"
-version = "0.6.2"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86f4aa3ad99f2088c990dfa82d367e19cb29268ed67c574d10d0a4bfe71f07e0"
+checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "sqlx"
-version = "0.8.6"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fefb893899429669dcdd979aff487bd78f4064e5e7907e4269081e0ef7d97dc"
+checksum = "378620ccc25c62c89d8be1c819e76a88d59bdcc3304733330788948e619bfd71"
 dependencies = [
  "sqlx-core",
  "sqlx-macros",
@@ -3002,12 +3017,13 @@ dependencies = [
 
 [[package]]
 name = "sqlx-core"
-version = "0.8.6"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee6798b1838b6a0f69c007c133b8df5866302197e404e8b6ee8ed3e3a5e68dc6"
+checksum = "05b44e85bf579a8eeb4ceaa77a3a523baf2bf0e9bac7e40f405d537b5d2d5ccb"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
+ "cfg-if",
  "crc",
  "crossbeam-queue",
  "either",
@@ -3016,19 +3032,18 @@ dependencies = [
  "futures-intrusive",
  "futures-io",
  "futures-util",
- "hashbrown 0.15.5",
+ "hashbrown 0.16.1",
  "hashlink",
  "indexmap",
  "log",
  "memchr",
  "native-tls",
- "once_cell",
  "percent-encoding",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "smallvec",
- "thiserror 2.0.18",
+ "thiserror",
  "tokio",
  "tokio-stream",
  "tracing",
@@ -3037,49 +3052,49 @@ dependencies = [
 
 [[package]]
 name = "sqlx-macros"
-version = "0.8.6"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2d452988ccaacfbf5e0bdbc348fb91d7c8af5bee192173ac3636b5fb6e6715d"
+checksum = "bd2b84f2bc39a5705ef27ec785a11c934a41bbd4a24941e257927cddc26b60bf"
 dependencies = [
  "proc-macro2",
  "quote",
  "sqlx-core",
  "sqlx-macros-core",
- "syn 2.0.114",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "sqlx-macros-core"
-version = "0.8.6"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19a9c1841124ac5a61741f96e1d9e2ec77424bf323962dd894bdb93f37d5219b"
+checksum = "fb8d96de5fdc85a5c4ec813432b523ec637e80ba98f046555f75f7908ddac7c3"
 dependencies = [
+ "cfg-if",
  "dotenvy",
  "either",
  "heck",
  "hex",
- "once_cell",
  "proc-macro2",
  "quote",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "sqlx-core",
  "sqlx-postgres",
- "syn 2.0.114",
+ "syn 2.0.119",
  "tokio",
  "url",
 ]
 
 [[package]]
 name = "sqlx-postgres"
-version = "0.8.6"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db58fcd5a53cf07c184b154801ff91347e4c30d17a3562a635ff028ad5deda46"
+checksum = "87a2bdd6e83f6b3ea525ca9fee568030508b58355a43d0b2c1674d5f79dcd65e"
 dependencies = [
  "atoi",
- "base64",
- "bitflags 2.10.0",
+ "base64 0.22.1",
+ "bitflags",
  "byteorder",
  "crc",
  "dotenvy",
@@ -3090,22 +3105,20 @@ dependencies = [
  "hex",
  "hkdf",
  "hmac",
- "home",
  "itoa",
  "log",
  "md-5",
  "memchr",
- "once_cell",
- "rand 0.8.5",
+ "rand 0.10.2",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.11.0",
  "smallvec",
  "sqlx-core",
  "stringprep",
- "thiserror 2.0.18",
+ "thiserror",
  "tracing",
- "whoami 1.6.1",
+ "whoami",
 ]
 
 [[package]]
@@ -3144,9 +3157,20 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.114"
+version = "2.0.119"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4d107df263a3013ef9b1879b0df87d706ff80f65a86ea879bd9c31f9b307c2a"
+checksum = "872831b642d1a07999a962a351ed35b955ea2cfc8f3862091e2a240a84f17297"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3170,7 +3194,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -3181,9 +3205,9 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tar"
-version = "0.4.44"
+version = "0.4.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d863878d212c87a19c1a610eb53bb01fe12951c0501cf5a0d65f724914a667a"
+checksum = "3f6221d9a6003c78398e3b239969f352578258df48c8eb051caadae0015bc840"
 dependencies = [
  "filetime",
  "libc",
@@ -3192,24 +3216,24 @@ dependencies = [
 
 [[package]]
 name = "target-lexicon"
-version = "0.13.4"
+version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1dd07eb858a2067e2f3c7155d54e929265c264e6f37efe3ee7a8d1b5a1dd0ba"
+checksum = "adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca"
 
 [[package]]
 name = "target-triple"
-version = "0.1.4"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ac9aa371f599d22256307c24a9d748c041e548cbf599f35d890f9d365361790"
+checksum = "c3a6bfce3d99adfa72d24750a61f782f3036a81e7f86d8841ee1326deaebd171"
 
 [[package]]
 name = "tempfile"
-version = "3.24.0"
+version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "655da9c7eb6305c55742045d5a8d2037996d61d8de95806335c7c86ce0f82e9c"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
@@ -3217,53 +3241,22 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.69"
+version = "2.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+checksum = "ec86235f5fcc2a73650310756d2ac5b138a5780bbbdfae3eeccec992c435ba4f"
 dependencies = [
- "thiserror-impl 1.0.69",
-]
-
-[[package]]
-name = "thiserror"
-version = "2.0.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
-dependencies = [
- "thiserror-impl 2.0.18",
+ "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.69"
+version = "2.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+checksum = "bc04cd3e1236dd4a98afca4569f2deb3f120e5422a4023be2cb683f8486292af"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
-]
-
-[[package]]
-name = "thiserror-impl"
-version = "2.0.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.114",
-]
-
-[[package]]
-name = "thrift"
-version = "0.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e54bc85fc7faa8bc175c4bab5b92ba8d9a3ce893d0e9f42cc455c8ab16a9e09"
-dependencies = [
- "byteorder",
- "integer-encoding",
- "ordered-float",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -3277,9 +3270,9 @@ dependencies = [
 
 [[package]]
 name = "tinystr"
-version = "0.8.2"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42d3e9c45c09de15d06dd8acf5f4e0e399e85927b7f00711024eb7ae10fa4869"
+checksum = "b1e27c91459209c2986af3dcf603a5a74a4368754ce37414f59acc971167f643"
 dependencies = [
  "displaydoc",
  "zerovec",
@@ -3297,9 +3290,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.10.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa5fdc3bce6191a1dbc8c02d5c8bffcf557bafa17c124c5264a458f1b0613fa"
+checksum = "bb4ebadaa0af04fab11ae01eb5f9fdb5f9c5b875506e210e71c07873528baa7f"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -3312,14 +3305,14 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.49.0"
+version = "1.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72a2903cd7736441aac9df9d7688bd0ce48edccaadf181c3b90be801e81d3d86"
+checksum = "202caea871b69668250d242070849eb495be178ed697a3e98aebce5bc81a0bed"
 dependencies = [
  "bytes",
  "libc",
  "mio",
- "parking_lot 0.12.5",
+ "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
  "socket2",
@@ -3329,13 +3322,13 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.6.0"
+version = "2.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af407857209536a95c8e56f8231ef2c2e2aff839b22e07a1ffcbc617e9db9fa5"
+checksum = "78773a2a397f451582ce068015985c33193cf6dea8b74d2a639fe457b2f07b0e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -3350,9 +3343,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-postgres"
-version = "0.7.16"
+version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcea47c8f71744367793f16c2db1f11cb859d28f436bdb4ca9193eb1f787ee42"
+checksum = "a528f7d280f6d5b9cd149635c8705b0dd049754bc67d81d31fa25169a93809d3"
 dependencies = [
  "async-trait",
  "byteorder",
@@ -3361,24 +3354,34 @@ dependencies = [
  "futures-channel",
  "futures-util",
  "log",
- "parking_lot 0.12.5",
+ "parking_lot",
  "percent-encoding",
  "phf",
  "pin-project-lite",
  "postgres-protocol",
  "postgres-types",
- "rand 0.9.2",
+ "rand 0.10.2",
  "socket2",
  "tokio",
  "tokio-util",
- "whoami 2.0.2",
+ "whoami",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+dependencies = [
+ "rustls",
+ "tokio",
 ]
 
 [[package]]
 name = "tokio-stream"
-version = "0.1.18"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70"
+checksum = "a3d06f0b082ba57c26b79407372e57cf2a1e28124f78e9479fe80322cf53420b"
 dependencies = [
  "futures-core",
  "pin-project-lite",
@@ -3387,31 +3390,32 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.18"
+version = "0.7.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
+checksum = "494815d09bf52b5548659851081238f0ca39ff638363907596da739561c62c52"
 dependencies = [
  "bytes",
  "futures-core",
  "futures-sink",
+ "libc",
  "pin-project-lite",
  "tokio",
 ]
 
 [[package]]
 name = "toml_datetime"
-version = "0.7.5+spec-1.1.0"
+version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92e1cfed4a3038bc5a127e35a2d360f145e1f4b971b551a2ba5fd7aedf7e1347"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
 dependencies = [
  "serde_core",
 ]
 
 [[package]]
 name = "toml_edit"
-version = "0.23.10+spec-1.0.0"
+version = "0.25.13+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84c8b9f757e028cee9fa244aea147aab2a9ec09d5325a9b01e0a49730c2b5269"
+checksum = "6975367e4d2ef766d86af01ffad14b622fecc8d4357a998fbc4deb6e9bacaf9b"
 dependencies = [
  "indexmap",
  "toml_datetime",
@@ -3421,9 +3425,9 @@ dependencies = [
 
 [[package]]
 name = "toml_parser"
-version = "1.0.6+spec-1.1.0"
+version = "1.1.3+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3198b4b0a8e11f09dd03e133c0280504d0801269e9afa46362ffde1cbeebf44"
+checksum = "1d38ac1cf9b95face32296c0a3ede1fdc270627c9d9c02a7274dd6d960dc4d56"
 dependencies = [
  "winnow",
 ]
@@ -3445,20 +3449,20 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.6.8"
+version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
+checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags",
  "bytes",
  "futures-util",
  "http",
  "http-body",
- "iri-string",
  "pin-project-lite",
  "tower",
  "tower-layer",
  "tower-service",
+ "url",
 ]
 
 [[package]]
@@ -3493,7 +3497,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -3513,15 +3517,15 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "twox-hash"
-version = "2.1.2"
+version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ea3136b675547379c4bd395ca6b938e5ad3c3d20fad76e7fe85f9e0d011419c"
+checksum = "8464ec13c3691491391d9fce00f6416c9a48e46972f72d7865688be2080192c9"
 
 [[package]]
 name = "typenum"
-version = "1.19.0"
+version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "unarray"
@@ -3537,9 +3541,9 @@ checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.22"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
+checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "unicode-normalization"
@@ -3563,12 +3567,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
 
 [[package]]
-name = "unindent"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7264e107f553ccae879d21fbea1d6724ac785e8c3bfc762137959b5802826ef3"
-
-[[package]]
 name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3576,18 +3574,31 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "ureq"
-version = "2.12.1"
+version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02d1a66277ed75f640d608235660df48c8e3c19f3b4edb6a263315626cc3c01d"
+checksum = "972d7902c8735f2695410b8aed7df6ed12a47394aa1c8d7af49f0497b731a94d"
 dependencies = [
- "base64",
+ "base64 0.23.1",
  "flate2",
  "log",
- "once_cell",
+ "percent-encoding",
  "rustls",
  "rustls-pki-types",
- "url",
- "webpki-roots 0.26.11",
+ "ureq-proto",
+ "utf8-zero",
+ "webpki-roots",
+]
+
+[[package]]
+name = "ureq-proto"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da5f78b09e6941e1a0f2e30e695e4b120377b54d5e0aec11b594bb57b3971613"
+dependencies = [
+ "base64 0.23.1",
+ "http",
+ "httparse",
+ "log",
 ]
 
 [[package]]
@@ -3601,6 +3612,12 @@ dependencies = [
  "percent-encoding",
  "serde",
 ]
+
+[[package]]
+name = "utf8-zero"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8c0a043c9540bae7c578c88f91dda8bd82e59ae27c21baca69c8b191aaf5a6e"
 
 [[package]]
 name = "utf8_iter"
@@ -3675,18 +3692,12 @@ dependencies = [
 
 [[package]]
 name = "wasip2"
-version = "1.0.2+wasi-0.2.9"
+version = "1.0.4+wasi-0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
+checksum = "b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487"
 dependencies = [
  "wit-bindgen",
 ]
-
-[[package]]
-name = "wasite"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8dad83b4f25e74f184f64c43b150b91efe7647395b42289f38e50566d82855b"
 
 [[package]]
 name = "wasite"
@@ -3699,9 +3710,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.108"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64024a30ec1e37399cf85a7ffefebdb72205ca1c972291c51512360d90bd8566"
+checksum = "1b70935747edd64d89de3efa29d73789b806c15798f8e7dca4d8ac356b50ce70"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -3713,23 +3724,19 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.58"
+version = "0.4.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70a6e77fd0ae8029c9ea0063f87c46fde723e7d887703d74ad2616d792e51e6f"
+checksum = "6b7777d5cc23d0e91404e53ce2d5e8ec7acae3026b16233dba62cd3246457950"
 dependencies = [
- "cfg-if",
- "futures-util",
  "js-sys",
- "once_cell",
  "wasm-bindgen",
- "web-sys",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.108"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "008b239d9c740232e71bd39e8ef6429d27097518b6b30bdf9086833bd5b6d608"
+checksum = "77775f8f3f7217702089053b94958f8f54061a3f663417df76e19cbdcca29bc1"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -3737,31 +3744,31 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.108"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5256bae2d58f54820e6490f9839c49780dff84c65aeab9e772f15d5f0e913a55"
+checksum = "e11d33f857dc2fb11b8bc75aee111aa9cbeb12cd9f25efd3d4c2a3dd4e235284"
 dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.119",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.108"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f01b580c9ac74c8d8f0c0e4afb04eeef2acf145458e52c03845ee9cd23e3d12"
+checksum = "7ef64dbcc55df09c7e5a46182d181c2cfa3e925f3da937ea764728b4bbb9dcbf"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "wasm-streams"
-version = "0.4.2"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
+checksum = "9d1ec4f6517c9e11ae630e200b2b65d193279042e28edd4a2cda233e46670bbb"
 dependencies = [
  "futures-util",
  "js-sys",
@@ -3771,25 +3778,24 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasm-timer"
-version = "0.2.5"
+name = "wasmtimer"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be0ecb0db480561e9a7642b5d3e4187c128914e58aa84330b9493e3eb68c5e7f"
+checksum = "1c598d6b99ea013e35844697fc4670d08339d5cda15588f193c6beedd12f644b"
 dependencies = [
  "futures",
  "js-sys",
- "parking_lot 0.11.2",
+ "parking_lot",
  "pin-utils",
+ "slab",
  "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
 ]
 
 [[package]]
 name = "web-sys"
-version = "0.3.85"
+version = "0.3.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "312e32e551d92129218ea9a2452120f4aabc03529ef03e4d0d82fb2780608598"
+checksum = "c435338968042f4f59a557f690a253676d47ce13ceb55d70100e7facf6620a30"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -3797,40 +3803,23 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
-version = "0.26.11"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
-dependencies = [
- "webpki-roots 1.0.5",
-]
-
-[[package]]
-name = "webpki-roots"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12bed680863276c63889429bfd6cab3b99943659923822de1c8a39c49e4d722c"
+checksum = "7dcd9d09a39985f5344844e66b0c530a33843579125f23e21e9f0f220850f22a"
 dependencies = [
  "rustls-pki-types",
 ]
 
 [[package]]
 name = "whoami"
-version = "1.6.1"
+version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d4a4db5077702ca3015d3d02d74974948aba2ad9e12ab7df718ee64ccd7e97d"
+checksum = "626c4bac6755d76ffc12cb01b2eac751db1996b9e0041de9aa02c8c211ddc82c"
 dependencies = [
+ "libc",
  "libredox",
- "wasite 0.1.0",
-]
-
-[[package]]
-name = "whoami"
-version = "2.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ace4d5c7b5ab3d99629156d4e0997edbe98a4beb6d5ba99e2cae830207a81983"
-dependencies = [
- "libredox",
- "wasite 1.0.2",
+ "objc2-system-configuration",
+ "wasite",
  "web-sys",
 ]
 
@@ -3886,7 +3875,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -3897,7 +3886,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -3926,29 +3915,11 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
-dependencies = [
- "windows-targets 0.48.5",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.60.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
-dependencies = [
- "windows-targets 0.53.5",
+ "windows-targets",
 ]
 
 [[package]]
@@ -3962,57 +3933,19 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
-dependencies = [
- "windows_aarch64_gnullvm 0.48.5",
- "windows_aarch64_msvc 0.48.5",
- "windows_i686_gnu 0.48.5",
- "windows_i686_msvc 0.48.5",
- "windows_x86_64_gnu 0.48.5",
- "windows_x86_64_gnullvm 0.48.5",
- "windows_x86_64_msvc 0.48.5",
-]
-
-[[package]]
-name = "windows-targets"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm 0.52.6",
- "windows_aarch64_msvc 0.52.6",
- "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm 0.52.6",
- "windows_i686_msvc 0.52.6",
- "windows_x86_64_gnu 0.52.6",
- "windows_x86_64_gnullvm 0.52.6",
- "windows_x86_64_msvc 0.52.6",
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
 ]
-
-[[package]]
-name = "windows-targets"
-version = "0.53.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
-dependencies = [
- "windows-link",
- "windows_aarch64_gnullvm 0.53.1",
- "windows_aarch64_msvc 0.53.1",
- "windows_i686_gnu 0.53.1",
- "windows_i686_gnullvm 0.53.1",
- "windows_i686_msvc 0.53.1",
- "windows_x86_64_gnu 0.53.1",
- "windows_x86_64_gnullvm 0.53.1",
- "windows_x86_64_msvc 0.53.1",
-]
-
-[[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -4021,34 +3954,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
-
-[[package]]
 name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -4057,28 +3966,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
-name = "windows_i686_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
-
-[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
-
-[[package]]
-name = "windows_i686_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -4087,34 +3978,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
-name = "windows_i686_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
-
-[[package]]
 name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -4123,49 +3990,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
-
-[[package]]
 name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
-name = "windows_x86_64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
-
-[[package]]
 name = "winnow"
-version = "0.7.14"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a5364e9d77fcdeeaa6062ced926ee3381faa2ee02d3eb83a5c27a8825540829"
+checksum = "23b97319f7b8343df12cc98938e5c3eb436064524c8d2b4e30a1d3a36eecdf81"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
 name = "wit-bindgen"
-version = "0.51.0"
+version = "0.57.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "writeable"
-version = "0.6.2"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
+checksum = "3ad82d2a33cdc9674dc7465672f271e096168fcdbe0f799d9e6db8c5892679dc"
 
 [[package]]
 name = "wyz"
@@ -4188,9 +4037,9 @@ dependencies = [
 
 [[package]]
 name = "yoke"
-version = "0.8.1"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72d6e5c6afb84d73944e5cedb052c4680d5657337201555f9f2a16b7406d4954"
+checksum = "709fe23a0424b6a435d82152b1bd3fdfb0833487d5fa90d05d42762a9891fef5"
 dependencies = [
  "stable_deref_trait",
  "yoke-derive",
@@ -4199,68 +4048,68 @@ dependencies = [
 
 [[package]]
 name = "yoke-derive"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.119",
  "synstructure",
 ]
 
 [[package]]
 name = "zerocopy"
-version = "0.8.33"
+version = "0.8.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "668f5168d10b9ee831de31933dc111a459c97ec93225beb307aed970d1372dfd"
+checksum = "556764e583adb45a9f8d413c2a147fa7e8d821e48e12b14fd560b607998b75eb"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.33"
+version = "0.8.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c7962b26b0a8685668b671ee4b54d007a67d4eaf05fda79ac0ecf41e32270f1"
+checksum = "f2ab42fc20575779bd240faa45f94a74256f755c0fa9e89f0ede20d91d0cdfc1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "zerofrom"
-version = "0.1.6"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
 dependencies = [
  "zerofrom-derive",
 ]
 
 [[package]]
 name = "zerofrom-derive"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.119",
  "synstructure",
 ]
 
 [[package]]
 name = "zeroize"
-version = "1.8.2"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
 
 [[package]]
 name = "zerotrie"
-version = "0.2.3"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a59c17a5562d507e4b54960e8569ebee33bee890c70aa3fe7b97e85a9fd7851"
+checksum = "4ea269c3bd32f0a32c321907a2ae912ba6f4649bb0fc764a15627e99a7095a3f"
 dependencies = [
  "displaydoc",
  "yoke",
@@ -4269,9 +4118,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec"
-version = "0.11.5"
+version = "0.11.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c28719294829477f525be0186d13efa9a3c602f7ec202ca9e353d310fb9a002"
+checksum = "94b5c6b5976d66c1d703c4fd17d3f5e43c8cedaacf604961b171adc7130896d8"
 dependencies = [
  "yoke",
  "zerofrom",
@@ -4280,26 +4129,26 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.11.2"
+version = "0.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
+checksum = "47402523226a02bfe5230160dc3ccc089aa6f6f19e7fcbb4e6f824bbb1b4aa62"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 3.0.3",
 ]
 
 [[package]]
 name = "zlib-rs"
-version = "0.5.5"
+version = "0.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40990edd51aae2c2b6907af74ffb635029d5788228222c4bb811e9351c0caad3"
+checksum = "34b31d188d9d685a4f9c7b46d6e36631b07058d2cfe190267adce54dc230bf12"
 
 [[package]]
 name = "zmij"
-version = "1.0.16"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfcd145825aace48cff44a8844de64bf75feec3080e0aa5cdbde72961ae51a65"
+checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"
 
 [[package]]
 name = "zstd"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,21 +7,32 @@ resolver = "2"
 
 [workspace.package]
 edition = "2021"
-# Minimum supported Rust version for the library targets. Note that the test
-# suite needs a newer toolchain than this (dev-dependencies floor at 1.89).
-rust-version = "1.84"
+# Minimum supported Rust version for the library targets. Raised from 1.84 by
+# the arrow 59 bump: arrow 59.x is edition 2024 and declares `rust-version =
+# "1.85"`, so 1.84 cannot even parse its manifest. Verified by hand:
+# `cargo +1.85 check --workspace --locked` passes, `cargo +1.84` fails.
+# Note that the *test* suite still needs a much newer toolchain than this: the
+# dev-dependency floor is 1.94, set by postgresql_embedded 0.21 / sqlx 0.9.
+rust-version = "1.85"
 
 [workspace.dependencies]
-arrow = ">=56.0.0"
+# Caret ranges (`59` == `>=59.0.0, <60.0.0`) rather than the open `>=56.0.0`
+# these used to be. Arrow types (`RecordBatch`, `Schema`, `Field`, ...) appear in
+# pgpq's *public* API, so an arrow major is a breaking change for pgpq's own
+# consumers and must not be picked up silently. The open range also let cargo
+# resolve a split tree -- direct deps at 56 while `arrow-pyarrow` pulled 59 --
+# which compiles but fails at the type level. Dependabot (see
+# .github/dependabot.yml) now proposes the major bumps instead.
+arrow = "59"
 # `default-features` must be declared here, not only at the use site: cargo
 # ignores (and warns about) `default-features = false` on an inherited
 # dependency unless the workspace entry sets it too. arrow-array's `default` is
 # empty today, so this is a correctness/lint fix rather than a behaviour change.
-arrow-array = { version = ">=56.0.0", default-features = false }
-arrow-schema = ">=56.0.0"
-arrow-json = ">=56.0.0"
-arrow-ipc = ">=56.0.0"
-parquet = ">=56.0.0"
+arrow-array = { version = "59", default-features = false }
+arrow-schema = "59"
+arrow-json = "59"
+arrow-ipc = "59"
+parquet = "59"
 
 [profile.bench.package.pgpq]
 debug = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,11 @@ rust-version = "1.84"
 
 [workspace.dependencies]
 arrow = ">=56.0.0"
-arrow-array = ">=56.0.0"
+# `default-features` must be declared here, not only at the use site: cargo
+# ignores (and warns about) `default-features = false` on an inherited
+# dependency unless the workspace entry sets it too. arrow-array's `default` is
+# empty today, so this is a correctness/lint fix rather than a behaviour change.
+arrow-array = { version = ">=56.0.0", default-features = false }
 arrow-schema = ">=56.0.0"
 arrow-json = ">=56.0.0"
 arrow-ipc = ">=56.0.0"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -22,16 +22,16 @@ enum_dispatch = "0.3.11"
 thiserror = "2.0.20"
 
 [dev-dependencies]
-rstest = ">=0.16.0"
+rstest = "0.26.1"
 parquet.workspace = true
-criterion = ">=0.4.0"
+criterion = "0.8.2"
 arrow = { workspace = true, features = ["ipc"]}
 arrow-ipc.workspace = true
-postgres-types = {version = ">=0.2.4", features = ["with-chrono-0_4"]}
-ureq = "2.6.2"
-postgresql_embedded = { version = "0.20.0", features = ["blocking"] }
+postgres-types = {version = "0.2.14", features = ["with-chrono-0_4"]}
+ureq = "3.4.0"
+postgresql_embedded = { version = "0.21.0", features = ["blocking"] }
 postgres = "0.19.12"
-similar = "2.7.0"
+similar = "3.1.2"
 console = "0.16.2"
 chrono = { version = "0.4.34", default-features = false, features = ["std"] }
 rust_decimal = { version = "1.36", features = ["db-postgres"] }

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -16,7 +16,7 @@ authors = ["Adrian Garcia Badaracco <dev@adriangb.com>"]
 bytes = "^1.4.0"
 arrow-schema.workspace = true
 enum_dispatch = "0.3.11"
-thiserror = "1.0.40"
+thiserror = "2.0.20"
 
 [dependencies.arrow-array]
 workspace = true

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -16,7 +16,6 @@ authors = ["Adrian Garcia Badaracco <dev@adriangb.com>"]
 bytes = "^1.4.0"
 arrow-schema.workspace = true
 enum_dispatch = "0.3.11"
-anyhow = "1.0.70"
 thiserror = "1.0.40"
 
 [dependencies.arrow-array]

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -15,12 +15,11 @@ authors = ["Adrian Garcia Badaracco <dev@adriangb.com>"]
 [dependencies]
 bytes = "^1.4.0"
 arrow-schema.workspace = true
+# `default-features = false` lives on `[workspace.dependencies.arrow-array]`;
+# repeating it here is what cargo used to warn about (and ignore).
+arrow-array.workspace = true
 enum_dispatch = "0.3.11"
 thiserror = "2.0.20"
-
-[dependencies.arrow-array]
-workspace = true
-default-features = false
 
 [dev-dependencies]
 rstest = ">=0.16.0"

--- a/core/benches/experiments.rs
+++ b/core/benches/experiments.rs
@@ -6,9 +6,10 @@ use arrow::record_batch::RecordBatchReader;
 use arrow_array::{Array, PrimitiveArray, RecordBatch};
 use arrow_schema::{DataType, Field, TimeUnit};
 use bytes::{BufMut, BytesMut};
-use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use criterion::{criterion_group, criterion_main, Criterion};
 use postgres_types::{ToSql, Type};
 use std::fs;
+use std::hint::black_box;
 use std::sync::Arc;
 
 fn get_start_end(row: usize, col: usize, n_rows: usize, offsets: &[usize]) -> (usize, usize) {

--- a/core/benches/yellow_cab_dataset.rs
+++ b/core/benches/yellow_cab_dataset.rs
@@ -73,7 +73,10 @@ pub fn benchmark_nyc_taxi_full(c: &mut Criterion) {
     group.sampling_mode(criterion::SamplingMode::Flat);
     group.sample_size(10); // the minimum
 
-    let (batches, schema) = setup(Some(100));
+    // `None` = read every batch in the dataset. This said `Some(100)`, which is
+    // exactly what `benchmark_nyc_taxi_small` uses, so the "full" benchmark was
+    // silently measuring the same small slice.
+    let (batches, schema) = setup(None);
     group.bench_function("NYC Yello Taxi full", |b| {
         b.iter(|| bench(&batches, &schema))
     });

--- a/core/benches/yellow_cab_dataset.rs
+++ b/core/benches/yellow_cab_dataset.rs
@@ -5,11 +5,12 @@ use arrow::datatypes::{DataType, Schema, TimeUnit};
 use arrow::record_batch::RecordBatchReader;
 use arrow_array::RecordBatch;
 use bytes::BytesMut;
-use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use criterion::{criterion_group, criterion_main, Criterion};
 use parquet::arrow::arrow_reader::{ParquetRecordBatchReader, ParquetRecordBatchReaderBuilder};
 use pgpq::ArrowToPostgresBinaryEncoder;
 use std::fs;
 use std::fs::File;
+use std::hint::black_box;
 use std::io;
 use std::path::PathBuf;
 
@@ -22,12 +23,16 @@ fn download_dataset() -> File {
         .join("yellow_tripdata_2022-01.parquet");
     if !path.exists() {
         let mut file = File::create(path.clone()).expect("failed to create file");
-        let mut resp = ureq::get(
+        // ureq 3 returns an `http::Response<Body>`; the streaming reader now
+        // hangs off the body rather than the response itself. `into_reader()`
+        // (unlike `read_to_vec`) has no size cap, which matters here: the
+        // dataset is a few hundred MB.
+        let resp = ureq::get(
             "https://d37ci6vzurychx.cloudfront.net/trip-data/yellow_tripdata_2022-01.parquet",
         )
         .call()
         .expect("request failed");
-        io::copy(&mut resp.into_reader(), &mut file).expect("failed to copy content");
+        io::copy(&mut resp.into_body().into_reader(), &mut file).expect("failed to copy content");
     }
 
     File::open(path).expect("failed to create file")

--- a/core/fuzz/Cargo.toml
+++ b/core/fuzz/Cargo.toml
@@ -10,9 +10,14 @@ cargo-fuzz = true
 [dependencies]
 libfuzzer-sys = "0.4"
 arbitrary = { version = "1", features = ["derive"] }
-arrow-array = ">=56.0.0"
-arrow-buffer = ">=56.0.0"
-arrow-schema = ">=56.0.0"
+# Kept in lockstep with the root workspace's arrow pins. This crate is its own
+# workspace with its own (gitignored) lockfile, so it resolves arrow
+# independently -- an open `>=56.0.0` range here could resolve to a different
+# arrow major than the `pgpq` it path-depends on, and the two would not share
+# types.
+arrow-array = "59"
+arrow-buffer = "59"
+arrow-schema = "59"
 bytes = "1"
 
 [dependencies.pgpq]

--- a/core/tests/integration_tests.rs
+++ b/core/tests/integration_tests.rs
@@ -1174,7 +1174,8 @@ fn validate_snapshots() {
 }
 
 // from https://github.com/mitsuhiko/similar/blob/main/examples/terminal.rs
-fn pretty_print_diff(diff: TextDiff<'_, '_, '_, str>) {
+// similar 3 dropped the third ('bufs) lifetime from `TextDiff`.
+fn pretty_print_diff(diff: TextDiff<'_, '_, str>) {
     for op in diff.ops() {
         for change in diff.iter_changes(op) {
             let (sign, style) = match change.tag() {

--- a/json/Cargo.toml
+++ b/json/Cargo.toml
@@ -18,7 +18,8 @@ serde_json = "1.0.94"
 
 [dependencies.pyo3]
 version = "^0.25.1"
-features = ["extension-module", "abi3-py39", "py-clone"]
+# Matches `requires-python = ">=3.10"` in json/pyproject.toml (#54).
+features = ["extension-module", "abi3-py310", "py-clone"]
 
 [package.metadata.maturin]
 name = "arrow_json._arrow_json"

--- a/json/Cargo.toml
+++ b/json/Cargo.toml
@@ -17,7 +17,9 @@ serde = "1.0.158"
 serde_json = "1.0.94"
 
 [dependencies.pyo3]
-version = "^0.25.1"
+# Kept in lockstep with py/Cargo.toml and with the pyo3 that arrow 59's
+# `pyarrow` feature requires (^0.29).
+version = "0.29.2"
 # Matches `requires-python = ">=3.10"` in json/pyproject.toml (#54).
 features = ["extension-module", "abi3-py310", "py-clone"]
 

--- a/json/src/lib.rs
+++ b/json/src/lib.rs
@@ -11,11 +11,11 @@ use serde_json::{to_string, Value};
 
 #[pyfunction]
 #[pyo3(signature = (array, large = true))]
-fn array_to_utf8_json_array(
-    py: Python,
+fn array_to_utf8_json_array<'py>(
+    py: Python<'py>,
     array: &Bound<'_, PyAny>,
     large: bool,
-) -> PyResult<PyObject> {
+) -> PyResult<Bound<'py, PyAny>> {
     // This is super inefficient, leaving optimization as a TODO
     let array = make_array(ArrayData::from_pyarrow_bound(array)?);
 

--- a/py/Cargo.toml
+++ b/py/Cargo.toml
@@ -17,7 +17,10 @@ bytes = "^1.4.0"
 pgpq = { path = "../core" }
 
 [dependencies.pyo3]
-version = "^0.25.1"
+# Must match the pyo3 that `arrow`'s `pyarrow` feature pulls in via
+# `arrow-pyarrow` (arrow 59.x -> pyo3 ^0.29), otherwise the `FromPyArrow`
+# impls take a `Bound` from a different pyo3 and nothing type-checks.
+version = "0.29.2"
 # abi3-py310 matches `requires-python = ">=3.10"` in py/pyproject.toml. They
 # disagreed before (abi3-py39), which is what stamped a too-low floor into the
 # wheel filename while the metadata said 3.10 (#54).

--- a/py/Cargo.toml
+++ b/py/Cargo.toml
@@ -18,7 +18,10 @@ pgpq = { path = "../core" }
 
 [dependencies.pyo3]
 version = "^0.25.1"
-features = ["extension-module", "abi3-py39", "py-clone"]
+# abi3-py310 matches `requires-python = ">=3.10"` in py/pyproject.toml. They
+# disagreed before (abi3-py39), which is what stamped a too-low floor into the
+# wheel filename while the metadata said 3.10 (#54).
+features = ["extension-module", "abi3-py310", "py-clone"]
 
 [package.metadata.maturin]
 name = "pgpq._pgpq"

--- a/py/src/encoders.rs
+++ b/py/src/encoders.rs
@@ -44,7 +44,7 @@ macro_rules! impl_passthrough_encoder_builder {
                 other: &Self,
                 op: CompareOp,
                 py: Python<'_>,
-            ) -> PyResult<PyObject> {
+            ) -> PyResult<Py<PyAny>> {
                 let res = match op {
                     CompareOp::Eq => {
                         let result = (&self.inner == &other.inner)
@@ -141,7 +141,7 @@ macro_rules! impl_passthrough_encoder_builder_variable_output {
                 other: &Self,
                 op: CompareOp,
                 py: Python<'_>,
-            ) -> PyResult<PyObject> {
+            ) -> PyResult<Py<PyAny>> {
                 let res = match op {
                     CompareOp::Eq => {
                         let result = (&self.inner == &other.inner)
@@ -178,7 +178,7 @@ macro_rules! impl_passthrough_encoder_builder_variable_output {
     };
 }
 
-#[pyclass(module = "pgpq._pgpq")]
+#[pyclass(module = "pgpq._pgpq", from_py_object)]
 #[derive(Debug, Clone)]
 pub struct BooleanEncoderBuilder {
     field: Py<PyAny>,
@@ -186,7 +186,7 @@ pub struct BooleanEncoderBuilder {
 }
 impl_passthrough_encoder_builder!(BooleanEncoderBuilder);
 
-#[pyclass(module = "pgpq._pgpq")]
+#[pyclass(module = "pgpq._pgpq", from_py_object)]
 #[derive(Debug, Clone)]
 pub struct UInt8EncoderBuilder {
     field: Py<PyAny>,
@@ -194,7 +194,7 @@ pub struct UInt8EncoderBuilder {
 }
 impl_passthrough_encoder_builder!(UInt8EncoderBuilder);
 
-#[pyclass(module = "pgpq._pgpq")]
+#[pyclass(module = "pgpq._pgpq", from_py_object)]
 #[derive(Debug, Clone)]
 pub struct UInt16EncoderBuilder {
     field: Py<PyAny>,
@@ -202,7 +202,7 @@ pub struct UInt16EncoderBuilder {
 }
 impl_passthrough_encoder_builder!(UInt16EncoderBuilder);
 
-#[pyclass(module = "pgpq._pgpq")]
+#[pyclass(module = "pgpq._pgpq", from_py_object)]
 #[derive(Debug, Clone)]
 pub struct UInt32EncoderBuilder {
     field: Py<PyAny>,
@@ -210,7 +210,7 @@ pub struct UInt32EncoderBuilder {
 }
 impl_passthrough_encoder_builder!(UInt32EncoderBuilder);
 
-#[pyclass(module = "pgpq._pgpq")]
+#[pyclass(module = "pgpq._pgpq", from_py_object)]
 #[derive(Debug, Clone)]
 pub struct UInt64EncoderBuilder {
     field: Py<PyAny>,
@@ -218,7 +218,7 @@ pub struct UInt64EncoderBuilder {
 }
 impl_passthrough_encoder_builder!(UInt64EncoderBuilder);
 
-#[pyclass(module = "pgpq._pgpq")]
+#[pyclass(module = "pgpq._pgpq", from_py_object)]
 #[derive(Debug, Clone)]
 pub struct Int8EncoderBuilder {
     field: Py<PyAny>,
@@ -231,7 +231,7 @@ impl_passthrough_encoder_builder_variable_output!(
     pgpq::encoders::EncoderBuilder::Int8
 );
 
-#[pyclass(module = "pgpq._pgpq")]
+#[pyclass(module = "pgpq._pgpq", from_py_object)]
 #[derive(Debug, Clone)]
 pub struct Int16EncoderBuilder {
     field: Py<PyAny>,
@@ -239,7 +239,7 @@ pub struct Int16EncoderBuilder {
 }
 impl_passthrough_encoder_builder!(Int16EncoderBuilder);
 
-#[pyclass(module = "pgpq._pgpq")]
+#[pyclass(module = "pgpq._pgpq", from_py_object)]
 #[derive(Debug, Clone)]
 pub struct Int32EncoderBuilder {
     field: Py<PyAny>,
@@ -247,7 +247,7 @@ pub struct Int32EncoderBuilder {
 }
 impl_passthrough_encoder_builder!(Int32EncoderBuilder);
 
-#[pyclass(module = "pgpq._pgpq")]
+#[pyclass(module = "pgpq._pgpq", from_py_object)]
 #[derive(Debug, Clone)]
 pub struct Int64EncoderBuilder {
     field: Py<PyAny>,
@@ -255,7 +255,7 @@ pub struct Int64EncoderBuilder {
 }
 impl_passthrough_encoder_builder!(Int64EncoderBuilder);
 
-#[pyclass(module = "pgpq._pgpq")]
+#[pyclass(module = "pgpq._pgpq", from_py_object)]
 #[derive(Debug, Clone)]
 pub struct Float16EncoderBuilder {
     field: Py<PyAny>,
@@ -263,7 +263,7 @@ pub struct Float16EncoderBuilder {
 }
 impl_passthrough_encoder_builder!(Float16EncoderBuilder);
 
-#[pyclass(module = "pgpq._pgpq")]
+#[pyclass(module = "pgpq._pgpq", from_py_object)]
 #[derive(Debug, Clone)]
 pub struct Float32EncoderBuilder {
     field: Py<PyAny>,
@@ -271,7 +271,7 @@ pub struct Float32EncoderBuilder {
 }
 impl_passthrough_encoder_builder!(Float32EncoderBuilder);
 
-#[pyclass(module = "pgpq._pgpq")]
+#[pyclass(module = "pgpq._pgpq", from_py_object)]
 #[derive(Debug, Clone)]
 pub struct Float64EncoderBuilder {
     field: Py<PyAny>,
@@ -279,7 +279,7 @@ pub struct Float64EncoderBuilder {
 }
 impl_passthrough_encoder_builder!(Float64EncoderBuilder);
 
-#[pyclass(module = "pgpq._pgpq")]
+#[pyclass(module = "pgpq._pgpq", from_py_object)]
 #[derive(Debug, Clone)]
 pub struct Decimal32EncoderBuilder {
     field: Py<PyAny>,
@@ -287,7 +287,7 @@ pub struct Decimal32EncoderBuilder {
 }
 impl_passthrough_encoder_builder!(Decimal32EncoderBuilder);
 
-#[pyclass(module = "pgpq._pgpq")]
+#[pyclass(module = "pgpq._pgpq", from_py_object)]
 #[derive(Debug, Clone)]
 pub struct Decimal64EncoderBuilder {
     field: Py<PyAny>,
@@ -295,7 +295,7 @@ pub struct Decimal64EncoderBuilder {
 }
 impl_passthrough_encoder_builder!(Decimal64EncoderBuilder);
 
-#[pyclass(module = "pgpq._pgpq")]
+#[pyclass(module = "pgpq._pgpq", from_py_object)]
 #[derive(Debug, Clone)]
 pub struct Decimal128EncoderBuilder {
     field: Py<PyAny>,
@@ -303,7 +303,7 @@ pub struct Decimal128EncoderBuilder {
 }
 impl_passthrough_encoder_builder!(Decimal128EncoderBuilder);
 
-#[pyclass(module = "pgpq._pgpq")]
+#[pyclass(module = "pgpq._pgpq", from_py_object)]
 #[derive(Debug, Clone)]
 pub struct TimestampMicrosecondEncoderBuilder {
     field: Py<PyAny>,
@@ -311,7 +311,7 @@ pub struct TimestampMicrosecondEncoderBuilder {
 }
 impl_passthrough_encoder_builder!(TimestampMicrosecondEncoderBuilder);
 
-#[pyclass(module = "pgpq._pgpq")]
+#[pyclass(module = "pgpq._pgpq", from_py_object)]
 #[derive(Debug, Clone)]
 pub struct TimestampMillisecondEncoderBuilder {
     field: Py<PyAny>,
@@ -319,7 +319,7 @@ pub struct TimestampMillisecondEncoderBuilder {
 }
 impl_passthrough_encoder_builder!(TimestampMillisecondEncoderBuilder);
 
-#[pyclass(module = "pgpq._pgpq")]
+#[pyclass(module = "pgpq._pgpq", from_py_object)]
 #[derive(Debug, Clone)]
 pub struct TimestampSecondEncoderBuilder {
     field: Py<PyAny>,
@@ -327,7 +327,7 @@ pub struct TimestampSecondEncoderBuilder {
 }
 impl_passthrough_encoder_builder!(TimestampSecondEncoderBuilder);
 
-#[pyclass(module = "pgpq._pgpq")]
+#[pyclass(module = "pgpq._pgpq", from_py_object)]
 #[derive(Debug, Clone)]
 pub struct Date32EncoderBuilder {
     field: Py<PyAny>,
@@ -335,7 +335,7 @@ pub struct Date32EncoderBuilder {
 }
 impl_passthrough_encoder_builder!(Date32EncoderBuilder);
 
-#[pyclass(module = "pgpq._pgpq")]
+#[pyclass(module = "pgpq._pgpq", from_py_object)]
 #[derive(Debug, Clone)]
 pub struct Time32MillisecondEncoderBuilder {
     field: Py<PyAny>,
@@ -343,7 +343,7 @@ pub struct Time32MillisecondEncoderBuilder {
 }
 impl_passthrough_encoder_builder!(Time32MillisecondEncoderBuilder);
 
-#[pyclass(module = "pgpq._pgpq")]
+#[pyclass(module = "pgpq._pgpq", from_py_object)]
 #[derive(Debug, Clone)]
 pub struct Time32SecondEncoderBuilder {
     field: Py<PyAny>,
@@ -351,7 +351,7 @@ pub struct Time32SecondEncoderBuilder {
 }
 impl_passthrough_encoder_builder!(Time32SecondEncoderBuilder);
 
-#[pyclass(module = "pgpq._pgpq")]
+#[pyclass(module = "pgpq._pgpq", from_py_object)]
 #[derive(Debug, Clone)]
 pub struct Time64MicrosecondEncoderBuilder {
     field: Py<PyAny>,
@@ -359,7 +359,7 @@ pub struct Time64MicrosecondEncoderBuilder {
 }
 impl_passthrough_encoder_builder!(Time64MicrosecondEncoderBuilder);
 
-#[pyclass(module = "pgpq._pgpq")]
+#[pyclass(module = "pgpq._pgpq", from_py_object)]
 #[derive(Debug, Clone)]
 pub struct DurationMicrosecondEncoderBuilder {
     field: Py<PyAny>,
@@ -367,7 +367,7 @@ pub struct DurationMicrosecondEncoderBuilder {
 }
 impl_passthrough_encoder_builder!(DurationMicrosecondEncoderBuilder);
 
-#[pyclass(module = "pgpq._pgpq")]
+#[pyclass(module = "pgpq._pgpq", from_py_object)]
 #[derive(Debug, Clone)]
 pub struct DurationMillisecondEncoderBuilder {
     field: Py<PyAny>,
@@ -375,7 +375,7 @@ pub struct DurationMillisecondEncoderBuilder {
 }
 impl_passthrough_encoder_builder!(DurationMillisecondEncoderBuilder);
 
-#[pyclass(module = "pgpq._pgpq")]
+#[pyclass(module = "pgpq._pgpq", from_py_object)]
 #[derive(Debug, Clone)]
 pub struct DurationSecondEncoderBuilder {
     field: Py<PyAny>,
@@ -383,7 +383,7 @@ pub struct DurationSecondEncoderBuilder {
 }
 impl_passthrough_encoder_builder!(DurationSecondEncoderBuilder);
 
-#[pyclass(module = "pgpq._pgpq")]
+#[pyclass(module = "pgpq._pgpq", from_py_object)]
 #[derive(Debug, Clone)]
 pub struct StringEncoderBuilder {
     field: Py<PyAny>,
@@ -396,7 +396,7 @@ impl_passthrough_encoder_builder_variable_output!(
     pgpq::encoders::EncoderBuilder::String
 );
 
-#[pyclass(module = "pgpq._pgpq")]
+#[pyclass(module = "pgpq._pgpq", from_py_object)]
 #[derive(Debug, Clone)]
 pub struct LargeStringEncoderBuilder {
     field: Py<PyAny>,
@@ -409,7 +409,7 @@ impl_passthrough_encoder_builder_variable_output!(
     pgpq::encoders::EncoderBuilder::LargeString
 );
 
-#[pyclass(module = "pgpq._pgpq")]
+#[pyclass(module = "pgpq._pgpq", from_py_object)]
 #[derive(Debug, Clone)]
 pub struct StringViewEncoderBuilder {
     field: Py<PyAny>,
@@ -422,7 +422,7 @@ impl_passthrough_encoder_builder_variable_output!(
     pgpq::encoders::EncoderBuilder::StringView
 );
 
-#[pyclass(module = "pgpq._pgpq")]
+#[pyclass(module = "pgpq._pgpq", from_py_object)]
 #[derive(Debug, Clone)]
 pub struct BinaryEncoderBuilder {
     field: Py<PyAny>,
@@ -430,7 +430,7 @@ pub struct BinaryEncoderBuilder {
 }
 impl_passthrough_encoder_builder!(BinaryEncoderBuilder);
 
-#[pyclass(module = "pgpq._pgpq")]
+#[pyclass(module = "pgpq._pgpq", from_py_object)]
 #[derive(Debug, Clone)]
 pub struct LargeBinaryEncoderBuilder {
     field: Py<PyAny>,
@@ -438,7 +438,7 @@ pub struct LargeBinaryEncoderBuilder {
 }
 impl_passthrough_encoder_builder!(LargeBinaryEncoderBuilder);
 
-#[pyclass(module = "pgpq._pgpq")]
+#[pyclass(module = "pgpq._pgpq", from_py_object)]
 #[derive(Debug, Clone)]
 pub struct StructEncoderBuilder {
     field: Py<PyAny>,
@@ -497,7 +497,7 @@ macro_rules! impl_list {
                 other: &Self,
                 op: CompareOp,
                 py: Python<'_>,
-            ) -> PyResult<PyObject> {
+            ) -> PyResult<Py<PyAny>> {
                 let res = match op {
                     CompareOp::Eq => {
                         let result = (&self.inner == &other.inner)
@@ -540,7 +540,7 @@ macro_rules! impl_list {
     };
 }
 
-#[pyclass(module = "pgpq._pgpq")]
+#[pyclass(module = "pgpq._pgpq", from_py_object)]
 #[derive(Debug, Clone)]
 pub struct ListEncoderBuilder {
     field: Py<PyAny>,
@@ -552,7 +552,7 @@ impl_list!(
     pgpq::encoders::ListEncoderBuilder::new_with_inner
 );
 
-#[pyclass(module = "pgpq._pgpq")]
+#[pyclass(module = "pgpq._pgpq", from_py_object)]
 #[derive(Debug, Clone)]
 pub struct LargeListEncoderBuilder {
     field: Py<PyAny>,
@@ -863,13 +863,14 @@ impl EncoderBuilder {
 
 impl From<pgpq::encoders::EncoderBuilder> for EncoderBuilder {
     fn from(value: pgpq::encoders::EncoderBuilder) -> Self {
-        Python::with_gil(|py| match &value {
+        Python::attach(|py| match &value {
             pgpq::encoders::EncoderBuilder::Boolean(inner) => {
                 let field = inner.field();
                 EncoderBuilder::Boolean(BooleanEncoderBuilder {
                     field: field
                         .to_pyarrow(py)
-                        .expect("Field to_pyarrow should not fail"),
+                        .expect("Field to_pyarrow should not fail")
+                        .unbind(),
                     inner: value,
                 })
             }
@@ -878,7 +879,8 @@ impl From<pgpq::encoders::EncoderBuilder> for EncoderBuilder {
                 EncoderBuilder::UInt8(UInt8EncoderBuilder {
                     field: field
                         .to_pyarrow(py)
-                        .expect("Field to_pyarrow should not fail"),
+                        .expect("Field to_pyarrow should not fail")
+                        .unbind(),
                     inner: value,
                 })
             }
@@ -887,7 +889,8 @@ impl From<pgpq::encoders::EncoderBuilder> for EncoderBuilder {
                 EncoderBuilder::UInt16(UInt16EncoderBuilder {
                     field: field
                         .to_pyarrow(py)
-                        .expect("Field to_pyarrow should not fail"),
+                        .expect("Field to_pyarrow should not fail")
+                        .unbind(),
                     inner: value,
                 })
             }
@@ -896,7 +899,8 @@ impl From<pgpq::encoders::EncoderBuilder> for EncoderBuilder {
                 EncoderBuilder::UInt32(UInt32EncoderBuilder {
                     field: field
                         .to_pyarrow(py)
-                        .expect("Field to_pyarrow should not fail"),
+                        .expect("Field to_pyarrow should not fail")
+                        .unbind(),
                     inner: value,
                 })
             }
@@ -905,7 +909,8 @@ impl From<pgpq::encoders::EncoderBuilder> for EncoderBuilder {
                 EncoderBuilder::UInt64(UInt64EncoderBuilder {
                     field: field
                         .to_pyarrow(py)
-                        .expect("Field to_pyarrow should not fail"),
+                        .expect("Field to_pyarrow should not fail")
+                        .unbind(),
                     inner: value,
                 })
             }
@@ -915,7 +920,8 @@ impl From<pgpq::encoders::EncoderBuilder> for EncoderBuilder {
                 EncoderBuilder::Int8(Int8EncoderBuilder {
                     field: field
                         .to_pyarrow(py)
-                        .expect("Field to_pyarrow should not fail"),
+                        .expect("Field to_pyarrow should not fail")
+                        .unbind(),
                     inner: value,
                     output,
                 })
@@ -925,7 +931,8 @@ impl From<pgpq::encoders::EncoderBuilder> for EncoderBuilder {
                 EncoderBuilder::Int16(Int16EncoderBuilder {
                     field: field
                         .to_pyarrow(py)
-                        .expect("Field to_pyarrow should not fail"),
+                        .expect("Field to_pyarrow should not fail")
+                        .unbind(),
                     inner: value,
                 })
             }
@@ -934,7 +941,8 @@ impl From<pgpq::encoders::EncoderBuilder> for EncoderBuilder {
                 EncoderBuilder::Int32(Int32EncoderBuilder {
                     field: field
                         .to_pyarrow(py)
-                        .expect("Field to_pyarrow should not fail"),
+                        .expect("Field to_pyarrow should not fail")
+                        .unbind(),
                     inner: value,
                 })
             }
@@ -943,7 +951,8 @@ impl From<pgpq::encoders::EncoderBuilder> for EncoderBuilder {
                 EncoderBuilder::Int64(Int64EncoderBuilder {
                     field: field
                         .to_pyarrow(py)
-                        .expect("Field to_pyarrow should not fail"),
+                        .expect("Field to_pyarrow should not fail")
+                        .unbind(),
                     inner: value,
                 })
             }
@@ -952,7 +961,8 @@ impl From<pgpq::encoders::EncoderBuilder> for EncoderBuilder {
                 EncoderBuilder::Float16(Float16EncoderBuilder {
                     field: field
                         .to_pyarrow(py)
-                        .expect("Field to_pyarrow should not fail"),
+                        .expect("Field to_pyarrow should not fail")
+                        .unbind(),
                     inner: value,
                 })
             }
@@ -961,7 +971,8 @@ impl From<pgpq::encoders::EncoderBuilder> for EncoderBuilder {
                 EncoderBuilder::Float32(Float32EncoderBuilder {
                     field: field
                         .to_pyarrow(py)
-                        .expect("Field to_pyarrow should not fail"),
+                        .expect("Field to_pyarrow should not fail")
+                        .unbind(),
                     inner: value,
                 })
             }
@@ -970,7 +981,8 @@ impl From<pgpq::encoders::EncoderBuilder> for EncoderBuilder {
                 EncoderBuilder::Float64(Float64EncoderBuilder {
                     field: field
                         .to_pyarrow(py)
-                        .expect("Field to_pyarrow should not fail"),
+                        .expect("Field to_pyarrow should not fail")
+                        .unbind(),
                     inner: value,
                 })
             }
@@ -979,7 +991,8 @@ impl From<pgpq::encoders::EncoderBuilder> for EncoderBuilder {
                 EncoderBuilder::Decimal32(Decimal32EncoderBuilder {
                     field: field
                         .to_pyarrow(py)
-                        .expect("Field to_pyarrow should not fail"),
+                        .expect("Field to_pyarrow should not fail")
+                        .unbind(),
                     inner: value,
                 })
             }
@@ -988,7 +1001,8 @@ impl From<pgpq::encoders::EncoderBuilder> for EncoderBuilder {
                 EncoderBuilder::Decimal64(Decimal64EncoderBuilder {
                     field: field
                         .to_pyarrow(py)
-                        .expect("Field to_pyarrow should not fail"),
+                        .expect("Field to_pyarrow should not fail")
+                        .unbind(),
                     inner: value,
                 })
             }
@@ -997,7 +1011,8 @@ impl From<pgpq::encoders::EncoderBuilder> for EncoderBuilder {
                 EncoderBuilder::Decimal128(Decimal128EncoderBuilder {
                     field: field
                         .to_pyarrow(py)
-                        .expect("Field to_pyarrow should not fail"),
+                        .expect("Field to_pyarrow should not fail")
+                        .unbind(),
                     inner: value,
                 })
             }
@@ -1006,7 +1021,8 @@ impl From<pgpq::encoders::EncoderBuilder> for EncoderBuilder {
                 EncoderBuilder::TimestampMicrosecond(TimestampMicrosecondEncoderBuilder {
                     field: field
                         .to_pyarrow(py)
-                        .expect("Field to_pyarrow should not fail"),
+                        .expect("Field to_pyarrow should not fail")
+                        .unbind(),
                     inner: value,
                 })
             }
@@ -1015,7 +1031,8 @@ impl From<pgpq::encoders::EncoderBuilder> for EncoderBuilder {
                 EncoderBuilder::TimestampMillisecond(TimestampMillisecondEncoderBuilder {
                     field: field
                         .to_pyarrow(py)
-                        .expect("Field to_pyarrow should not fail"),
+                        .expect("Field to_pyarrow should not fail")
+                        .unbind(),
                     inner: value,
                 })
             }
@@ -1024,7 +1041,8 @@ impl From<pgpq::encoders::EncoderBuilder> for EncoderBuilder {
                 EncoderBuilder::TimestampSecond(TimestampSecondEncoderBuilder {
                     field: field
                         .to_pyarrow(py)
-                        .expect("Field to_pyarrow should not fail"),
+                        .expect("Field to_pyarrow should not fail")
+                        .unbind(),
                     inner: value,
                 })
             }
@@ -1033,7 +1051,8 @@ impl From<pgpq::encoders::EncoderBuilder> for EncoderBuilder {
                 EncoderBuilder::Date32(Date32EncoderBuilder {
                     field: field
                         .to_pyarrow(py)
-                        .expect("Field to_pyarrow should not fail"),
+                        .expect("Field to_pyarrow should not fail")
+                        .unbind(),
                     inner: value,
                 })
             }
@@ -1042,7 +1061,8 @@ impl From<pgpq::encoders::EncoderBuilder> for EncoderBuilder {
                 EncoderBuilder::Time32Millisecond(Time32MillisecondEncoderBuilder {
                     field: field
                         .to_pyarrow(py)
-                        .expect("Field to_pyarrow should not fail"),
+                        .expect("Field to_pyarrow should not fail")
+                        .unbind(),
                     inner: value,
                 })
             }
@@ -1051,7 +1071,8 @@ impl From<pgpq::encoders::EncoderBuilder> for EncoderBuilder {
                 EncoderBuilder::Time32Second(Time32SecondEncoderBuilder {
                     field: field
                         .to_pyarrow(py)
-                        .expect("Field to_pyarrow should not fail"),
+                        .expect("Field to_pyarrow should not fail")
+                        .unbind(),
                     inner: value,
                 })
             }
@@ -1060,7 +1081,8 @@ impl From<pgpq::encoders::EncoderBuilder> for EncoderBuilder {
                 EncoderBuilder::Time64Microsecond(Time64MicrosecondEncoderBuilder {
                     field: field
                         .to_pyarrow(py)
-                        .expect("Field to_pyarrow should not fail"),
+                        .expect("Field to_pyarrow should not fail")
+                        .unbind(),
                     inner: value,
                 })
             }
@@ -1069,7 +1091,8 @@ impl From<pgpq::encoders::EncoderBuilder> for EncoderBuilder {
                 EncoderBuilder::DurationMicrosecond(DurationMicrosecondEncoderBuilder {
                     field: field
                         .to_pyarrow(py)
-                        .expect("Field to_pyarrow should not fail"),
+                        .expect("Field to_pyarrow should not fail")
+                        .unbind(),
                     inner: value,
                 })
             }
@@ -1078,7 +1101,8 @@ impl From<pgpq::encoders::EncoderBuilder> for EncoderBuilder {
                 EncoderBuilder::DurationMillisecond(DurationMillisecondEncoderBuilder {
                     field: field
                         .to_pyarrow(py)
-                        .expect("Field to_pyarrow should not fail"),
+                        .expect("Field to_pyarrow should not fail")
+                        .unbind(),
                     inner: value,
                 })
             }
@@ -1087,7 +1111,8 @@ impl From<pgpq::encoders::EncoderBuilder> for EncoderBuilder {
                 EncoderBuilder::DurationSecond(DurationSecondEncoderBuilder {
                     field: field
                         .to_pyarrow(py)
-                        .expect("Field to_pyarrow should not fail"),
+                        .expect("Field to_pyarrow should not fail")
+                        .unbind(),
                     inner: value,
                 })
             }
@@ -1097,7 +1122,8 @@ impl From<pgpq::encoders::EncoderBuilder> for EncoderBuilder {
                 EncoderBuilder::String(StringEncoderBuilder {
                     field: field
                         .to_pyarrow(py)
-                        .expect("Field to_pyarrow should not fail"),
+                        .expect("Field to_pyarrow should not fail")
+                        .unbind(),
                     inner: value,
                     output,
                 })
@@ -1108,7 +1134,8 @@ impl From<pgpq::encoders::EncoderBuilder> for EncoderBuilder {
                 EncoderBuilder::LargeString(LargeStringEncoderBuilder {
                     field: field
                         .to_pyarrow(py)
-                        .expect("Field to_pyarrow should not fail"),
+                        .expect("Field to_pyarrow should not fail")
+                        .unbind(),
                     inner: value,
                     output,
                 })
@@ -1119,7 +1146,8 @@ impl From<pgpq::encoders::EncoderBuilder> for EncoderBuilder {
                 EncoderBuilder::StringView(StringViewEncoderBuilder {
                     field: field
                         .to_pyarrow(py)
-                        .expect("Field to_pyarrow should not fail"),
+                        .expect("Field to_pyarrow should not fail")
+                        .unbind(),
                     inner: value,
                     output,
                 })
@@ -1129,7 +1157,8 @@ impl From<pgpq::encoders::EncoderBuilder> for EncoderBuilder {
                 EncoderBuilder::Binary(BinaryEncoderBuilder {
                     field: field
                         .to_pyarrow(py)
-                        .expect("Field to_pyarrow should not fail"),
+                        .expect("Field to_pyarrow should not fail")
+                        .unbind(),
                     inner: value,
                 })
             }
@@ -1138,7 +1167,8 @@ impl From<pgpq::encoders::EncoderBuilder> for EncoderBuilder {
                 EncoderBuilder::LargeBinary(LargeBinaryEncoderBuilder {
                     field: field
                         .to_pyarrow(py)
-                        .expect("Field to_pyarrow should not fail"),
+                        .expect("Field to_pyarrow should not fail")
+                        .unbind(),
                     inner: value,
                 })
             }
@@ -1147,7 +1177,8 @@ impl From<pgpq::encoders::EncoderBuilder> for EncoderBuilder {
                 EncoderBuilder::List(ListEncoderBuilder {
                     field: field
                         .to_pyarrow(py)
-                        .expect("Field to_pyarrow should not fail"),
+                        .expect("Field to_pyarrow should not fail")
+                        .unbind(),
                     inner: value,
                 })
             }
@@ -1156,14 +1187,15 @@ impl From<pgpq::encoders::EncoderBuilder> for EncoderBuilder {
                 EncoderBuilder::LargeList(LargeListEncoderBuilder {
                     field: field
                         .to_pyarrow(py)
-                        .expect("Field to_pyarrow should not fail"),
+                        .expect("Field to_pyarrow should not fail")
+                        .unbind(),
                     inner: value,
                 })
             }
             pgpq::encoders::EncoderBuilder::Struct(inner) => {
                 let field = inner.field();
                 EncoderBuilder::Struct(StructEncoderBuilder {
-                    field: field.to_pyarrow(py).unwrap(),
+                    field: field.to_pyarrow(py).unwrap().unbind(),
                     inner: value,
                 })
             }

--- a/py/src/lib.rs
+++ b/py/src/lib.rs
@@ -40,7 +40,7 @@ impl ArrowToPostgresBinaryEncoder {
         })
     }
     #[staticmethod]
-    fn infer_encoder(py: Python, py_field: &Bound<'_, PyAny>) -> PyResult<PyObject> {
+    fn infer_encoder(py: Python, py_field: &Bound<'_, PyAny>) -> PyResult<Py<PyAny>> {
         let encoder = EncoderBuilder::try_new(py, py_field)?;
         Ok(encoder
             .into_pyobject(py)
@@ -83,7 +83,7 @@ impl ArrowToPostgresBinaryEncoder {
             .map_err(|e| PyValueError::new_err(format!("Failed to write batch: {:?}", e)))?;
 
         Ok(if self.buf.len() > BUFF_SIZE {
-            Python::with_gil(|py| PyBytes::new(py, &self.buf.split()[..]).unbind().into())
+            Python::attach(|py| PyBytes::new(py, &self.buf.split()[..]).unbind().into())
         } else {
             self.empty.clone()
         })

--- a/py/src/pg_schema.rs
+++ b/py/src/pg_schema.rs
@@ -22,7 +22,7 @@ macro_rules! impl_simple {
                 other: &Self,
                 op: CompareOp,
                 py: Python<'_>,
-            ) -> PyResult<PyObject> {
+            ) -> PyResult<Py<PyAny>> {
                 let res = match op {
                     CompareOp::Eq => {
                         let result = (self == other)
@@ -57,93 +57,93 @@ macro_rules! impl_simple {
     };
 }
 
-#[pyclass(module = "pgpq._pgpq")]
+#[pyclass(module = "pgpq._pgpq", from_py_object)]
 #[derive(Debug, Clone, PartialEq)]
 pub struct Bool;
 impl_simple!(Bool, pgpq::pg_schema::PostgresType::Bool);
 
-#[pyclass(module = "pgpq._pgpq")]
+#[pyclass(module = "pgpq._pgpq", from_py_object)]
 #[derive(Debug, Clone, PartialEq)]
 pub struct Bytea;
 impl_simple!(Bytea, pgpq::pg_schema::PostgresType::Bytea);
 
-#[pyclass(module = "pgpq._pgpq")]
+#[pyclass(module = "pgpq._pgpq", from_py_object)]
 #[derive(Debug, Clone, PartialEq)]
 pub struct Int8;
 impl_simple!(Int8, pgpq::pg_schema::PostgresType::Int8);
 
-#[pyclass(module = "pgpq._pgpq")]
+#[pyclass(module = "pgpq._pgpq", from_py_object)]
 #[derive(Debug, Clone, PartialEq)]
 pub struct Int2;
 impl_simple!(Int2, pgpq::pg_schema::PostgresType::Int2);
 
-#[pyclass(module = "pgpq._pgpq")]
+#[pyclass(module = "pgpq._pgpq", from_py_object)]
 #[derive(Debug, Clone, PartialEq)]
 pub struct Int4;
 impl_simple!(Int4, pgpq::pg_schema::PostgresType::Int4);
 
-#[pyclass(module = "pgpq._pgpq")]
+#[pyclass(module = "pgpq._pgpq", from_py_object)]
 #[derive(Debug, Clone, PartialEq)]
 pub struct Char;
 impl_simple!(Char, pgpq::pg_schema::PostgresType::Char);
 
-#[pyclass(module = "pgpq._pgpq")]
+#[pyclass(module = "pgpq._pgpq", from_py_object)]
 #[derive(Debug, Clone, PartialEq)]
 pub struct Text;
 impl_simple!(Text, pgpq::pg_schema::PostgresType::Text);
 
-#[pyclass(module = "pgpq._pgpq")]
+#[pyclass(module = "pgpq._pgpq", from_py_object)]
 #[derive(Debug, Clone, PartialEq)]
 pub struct Json;
 impl_simple!(Json, pgpq::pg_schema::PostgresType::Json);
 
-#[pyclass(module = "pgpq._pgpq")]
+#[pyclass(module = "pgpq._pgpq", from_py_object)]
 #[derive(Debug, Clone, PartialEq)]
 pub struct Jsonb;
 impl_simple!(Jsonb, pgpq::pg_schema::PostgresType::Jsonb);
 
-#[pyclass(module = "pgpq._pgpq")]
+#[pyclass(module = "pgpq._pgpq", from_py_object)]
 #[derive(Debug, Clone, PartialEq)]
 pub struct Float4;
 impl_simple!(Float4, pgpq::pg_schema::PostgresType::Float4);
 
-#[pyclass(module = "pgpq._pgpq")]
+#[pyclass(module = "pgpq._pgpq", from_py_object)]
 #[derive(Debug, Clone, PartialEq)]
 pub struct Float8;
 impl_simple!(Float8, pgpq::pg_schema::PostgresType::Float8);
 
-#[pyclass(module = "pgpq._pgpq")]
+#[pyclass(module = "pgpq._pgpq", from_py_object)]
 #[derive(Debug, Clone, PartialEq)]
 pub struct Numeric;
 impl_simple!(Numeric, pgpq::pg_schema::PostgresType::Numeric);
 
-#[pyclass(module = "pgpq._pgpq")]
+#[pyclass(module = "pgpq._pgpq", from_py_object)]
 #[derive(Debug, Clone, PartialEq)]
 pub struct Date;
 impl_simple!(Date, pgpq::pg_schema::PostgresType::Date);
 
-#[pyclass(module = "pgpq._pgpq")]
+#[pyclass(module = "pgpq._pgpq", from_py_object)]
 #[derive(Debug, Clone, PartialEq)]
 pub struct Time;
 impl_simple!(Time, pgpq::pg_schema::PostgresType::Time);
 
-#[pyclass(module = "pgpq._pgpq")]
+#[pyclass(module = "pgpq._pgpq", from_py_object)]
 #[derive(Debug, Clone, PartialEq)]
 pub struct Timestamp;
 impl_simple!(Timestamp, pgpq::pg_schema::PostgresType::Timestamp);
 
-#[pyclass(module = "pgpq._pgpq")]
+#[pyclass(module = "pgpq._pgpq", from_py_object)]
 #[derive(Debug, Clone, PartialEq)]
 pub struct Interval;
 impl_simple!(Interval, pgpq::pg_schema::PostgresType::Interval);
 
-#[pyclass(module = "pgpq._pgpq")]
+#[pyclass(module = "pgpq._pgpq", from_py_object)]
 #[derive(Debug, Clone, PartialEq)]
 pub struct List {
     inner: Box<Column>,
 }
 
-#[pyclass(module = "pgpq._pgpq")]
+#[pyclass(module = "pgpq._pgpq", from_py_object)]
 #[derive(Debug, Clone, PartialEq)]
 pub struct UserDefined {
     pub fields: Vec<Column>,
@@ -161,7 +161,7 @@ impl UserDefined {
     fn __str__(&self, py: Python) -> String {
         self.__repr__(py)
     }
-    fn __richcmp__(&self, other: &Self, op: CompareOp, py: Python<'_>) -> PyResult<PyObject> {
+    fn __richcmp__(&self, other: &Self, op: CompareOp, py: Python<'_>) -> PyResult<Py<PyAny>> {
         let res = match op {
             CompareOp::Eq => {
                 let result = (self == other)
@@ -213,7 +213,7 @@ impl List {
     fn __str__(&self, py: Python) -> String {
         self.__repr__(py)
     }
-    fn __richcmp__(&self, other: &Self, op: CompareOp, py: Python<'_>) -> PyResult<PyObject> {
+    fn __richcmp__(&self, other: &Self, op: CompareOp, py: Python<'_>) -> PyResult<Py<PyAny>> {
         let res = match op {
             CompareOp::Eq => {
                 let result = (self == other)
@@ -352,7 +352,7 @@ impl PythonRepr for PostgresType {
     }
 }
 
-#[pyclass(module = "pgpq._pgpq")]
+#[pyclass(module = "pgpq._pgpq", from_py_object)]
 #[derive(Debug, Clone, PartialEq)]
 pub struct Column {
     #[pyo3(get)]
@@ -473,7 +473,7 @@ impl Column {
     fn __str__(&self, py: Python) -> String {
         self.__repr__(py)
     }
-    fn __richcmp__(&self, other: &Self, op: CompareOp, py: Python<'_>) -> PyResult<PyObject> {
+    fn __richcmp__(&self, other: &Self, op: CompareOp, py: Python<'_>) -> PyResult<Py<PyAny>> {
         let res = match op {
             CompareOp::Eq => {
                 let result = (self == other)
@@ -519,7 +519,7 @@ impl PythonRepr for Column {
     }
 }
 
-#[pyclass(module = "pgpq._pgpq")]
+#[pyclass(module = "pgpq._pgpq", from_py_object)]
 #[derive(Debug, Clone, PartialEq)]
 pub struct PostgresSchema {
     #[pyo3(get)]
@@ -538,7 +538,7 @@ impl PostgresSchema {
     fn __str__(&self, py: Python) -> String {
         self.__repr__(py)
     }
-    fn __richcmp__(&self, other: &Self, op: CompareOp, py: Python<'_>) -> PyResult<PyObject> {
+    fn __richcmp__(&self, other: &Self, op: CompareOp, py: Python<'_>) -> PyResult<Py<PyAny>> {
         let res = match op {
             CompareOp::Eq => {
                 let result = (self == other)

--- a/py/src/template.py
+++ b/py/src/template.py
@@ -1,5 +1,9 @@
+# `from_py_object` is required from pyo3 0.29 on: `#[pyclass]` types that
+# implement Clone no longer get a `FromPyObject` impl implicitly, and these
+# builders are extracted from Python (dicts of encoders, lists of columns).
+# Keep this in sync with the hand-written classes in encoders.rs/pg_schema.rs.
 PYCLASS_TEMPLATE = """\
-#[pyclass(module = "pgpq._pgpq")]
+#[pyclass(module = "pgpq._pgpq", from_py_object)]
 struct {name} {{
     inner: encoders::EncoderBuilder,
 }}
@@ -67,8 +71,9 @@ types = [
     "Interval",
 ]
 
+# See the note on PYCLASS_TEMPLATE: pyo3 0.29 needs the `from_py_object` opt-in.
 TYPE_TEMPLATE = """\
-#[pyclass(module = "pgpq._pgpq")]
+#[pyclass(module = "pgpq._pgpq", from_py_object)]
 struct {name} {{
     inner: PostgresType,
 }}


### PR DESCRIPTION
Closes #66
Closes #54

The dependency catch-up from #66, plus the Dependabot config so it is the last manual one.

## Stacking

Developed on top of #77 → #74, then rebased through #75, #85 and #78 as they landed. It now sits directly on `main` (`a6257ce`) and targets `main` — no retargeting needed.

The rebase over the new test infrastructure was clean: the harness (`core/tests/harness/`), the proptest suite (`core/tests/proptest_roundtrip.rs`), the fuzz crate (`core/fuzz/`) and #85's decimal encoder rewrite **all compile and pass against arrow 59 + pyo3 0.29 with zero API changes required**. The only conflict in the whole series was `Cargo.lock`, resolved by regeneration rather than a textual merge (see below).

## Version set and the constraints behind it

| Dependency | Before | After |
|---|---|---|
| `arrow` / `arrow-*` / `parquet` | `>=56.0.0` (locked 56.0.0) | `59` (locked 59.2.0) |
| `pyo3` (py/, json/) | `^0.25.1` | `0.29.2` |
| `thiserror` (core) | 1.0.40 | 2.0.20 |
| `anyhow` (core) | 1.0.70 | removed (unused) |
| `criterion` (dev) | `>=0.4.0` | 0.8.2 |
| `ureq` (dev) | 2.6.2 | 3.4.0 |
| `rstest` (dev) | `>=0.16.0` | 0.26.1 |
| `postgresql_embedded` (dev) | 0.20.0 | 0.21.0 |
| `similar` (dev) | 2.7.0 | 3.1.2 |
| `postgres-types` (dev) | `>=0.2.4` | 0.2.14 |
| MSRV (`[workspace.package]`) | 1.84 | 1.85 |
| abi3 feature | `abi3-py39` | `abi3-py310` |

**arrow ↔ pyo3 are coupled.** `arrow`'s `pyarrow` feature pulls in the `arrow-pyarrow` crate, and `arrow-pyarrow` 59.2.0 depends on `pyo3 ^0.29`. Bumping one without the other yields a tree containing two pyo3 majors, where `FromPyArrow`/`ToPyArrow` hand back a `Bound` from the *other* pyo3 and nothing type-checks. **arrow 59.2.0 + pyo3 0.29.2 is the newest mutually compatible pair**, so both landed at their latest.

**Range style: `>=56.0.0` → `59`.** Two reasons. Arrow types (`RecordBatch`, `Schema`, `Field`) appear in pgpq's *public* API, so an arrow major is a breaking change for pgpq's own consumers and should not be picked up silently by a resolver. And the open range is what produced the split tree #66 noticed — direct deps pinned at 56 while `arrow-pyarrow` dragged in 59. Dependabot now proposes the majors instead.

**MSRV 1.84 → 1.85.** arrow 59.x is edition 2024 and declares `rust-version = "1.85"`; 1.84 cannot even parse its manifest. Bisected by hand with real toolchains: `cargo +1.85 check --workspace --locked` passes, `cargo +1.84` fails. Separately, the *dev-dependency* floor rose from 1.89 to **1.94** (postgresql_embedded 0.21 → sqlx 0.9). That does not affect the published library, and CI runs `stable`, but the comment in `Cargo.toml` records it.

**`pyarrow>=11` runtime floor: left alone.** arrow-pyarrow 59.2 prefers the PyCapsule protocol (`__arrow_c_schema__`, pyarrow ≥ 14) but still falls back to `_export_to_c`/`_import_from_c`, which predate pyarrow 11. Nothing in the bump requires a newer pyarrow at runtime, so the floor stays put. (`abi3-py310` does raise the *Python* floor for wheels from 3.9 to 3.10, which is the point of the #54 fix.)

## API churn fixed

pyo3 0.25 → 0.29:
- `PyObject` alias removed → `Py<PyAny>`.
- `Python::with_gil` removed → `Python::attach`.
- `#[pyclass]` types implementing `Clone` no longer derive `FromPyObject` implicitly. Every pyclass in `py/src` is extracted from Python somewhere, so they opt back in with `#[pyclass(..., from_py_object)]`; `ArrowToPostgresBinaryEncoder` is the one exception (not `Clone`, never extracted).

arrow 56 → 59:
- `ToPyArrow::to_pyarrow` now returns `Bound<'py, PyAny>` rather than `Py<PyAny>`.

dev-deps:
- criterion 0.8 deprecates `criterion::black_box` (the warning was already firing) → `std::hint::black_box`.
- ureq 3 returns `http::Response<Body>` and moved the reader onto the body → `resp.into_body().into_reader()` in the bench download helper.
- similar 3 dropped the third lifetime from `TextDiff`.

## Feature-resolution bug

cargo was warning that `default-features = false` on `[dependencies.arrow-array]` in `core/Cargo.toml` is **ignored**, because the `[workspace.dependencies]` entry did not specify it — so the intended no-default-features has silently never applied. Fixed at the workspace entry, where cargo honours it, and `core` now plainly inherits.

In practice nothing changes at the feature level: arrow-array's `default` feature set is empty in both 56 and 59. But the declaration now means what it says, and `cargo tree -e features -p pgpq --edges normal` no longer shows an `arrow-array feature "default"` edge (it did before). No use site needed the defaults added back — `core` is the only member that depends on `arrow-array` directly; `py/` and `json/` use `arrow` with `pyarrow`/`json`/`ipc` features and keep their defaults.

## Dependabot

`.github/dependabot.yml`, weekly, grouped:
- **cargo** (root — covers the whole workspace): the arrow family + pyo3 in one group, because splitting them produces trees that do not compile; everything else rolls up into one minor/patch PR, majors come through individually.
- **github-actions**: preserves the SHA-pinned `uses: owner/repo@<sha> # vX.Y.Z` format from #74.
- **uv**: the lockfile from #77.

## Verification

**CI on this PR is fully green** — every required check passes, including the Linux i686 builds and the Python build-and-test matrix for both wheels.

The table below is the local run on macOS (aarch64), all green:

| Check | Result |
|---|---|
| `cargo test --locked` | **211 passed, 0 failed** — 13 lib (incl. #85's `decimal_tests`), 196 `integration_tests` (incl. `validate_snapshots` + `validate_roundtrip_values`), 1 `decimal_wire_format` (#85), 1 `proptest_roundtrip` (#78) |
| `cargo clippy --locked --workspace --all-targets -- -D warnings` | clean (this is the one that covers **benches**; CI's `--all` does not) |
| `cargo +nightly fuzz build` | passes |
| `cargo clippy --locked --all -- -D warnings` | clean |
| `cargo clippy --locked --all --tests -- -D warnings` | clean |
| `cargo fmt --all -- --check` | clean |
| `cargo check --workspace --locked --all-targets` | clean, **no warnings** (the `default-features` warning is gone) |
| `cargo check -p pgpq --locked` | clean |
| `cargo package -p pgpq --locked` (build-verifies the published crate standalone) | clean |
| `cargo +1.85 check --workspace --locked` | passes |
| `cargo +1.84 check --workspace --locked` | fails as expected (arrow 59 manifest) |
| `make init` + `maturin develop` for both modules | both built `cp310-abi3` wheels |
| `pytest` | **23 passed** (the suite was slimmed to the binding layer by #75; includes #78's `test_roundtrip_arbitrary_primitive_tables` hypothesis test, exercised against the pyo3 0.29 wheel) |
| `uv lock --check` | up to date (no Python metadata changed, so no regen was needed) |
| `uv run pre-commit run --all-files` | all hooks pass |
| `uvx --from actionlint-py actionlint` | clean (no workflows touched; `dependabot.yml` is not a workflow) |

**No snapshot changes.** `validate_snapshots` passes byte-for-byte against the committed snapshots — including the 24 decimal/uint64 snapshots that #85 regenerated — so arrow 59 produces identical Postgres binary output for every supported type. No wire-format change to review.

## Integration notes (rebase over #75 / #85 / #78)

- **`Cargo.lock`** — the one conflict. Resolved by taking this branch's lock and letting cargo add the new entries, rather than a textual merge, which is how the split 56/59 tree gets resurrected. Asserted afterwards: **all 15 arrow crates at 59.2.0, a single `pyo3` 0.29.2, a single `thiserror` 2.0.20.**
- **`core/Cargo.toml`** — union: this branch's pins win where they overlap (`postgres-types` 0.2.14 over `>=0.2.4`), and #75's `chrono`/`rust_decimal` plus #78's `proptest` are taken verbatim.
- **`core/tests/integration_tests.rs`** — `pretty_print_diff` survived #75's rewrite, and the 2-lifetime `TextDiff<'_, '_, str>` fix for similar 3 applies on top of the new harness structure.
- **`core/fuzz/Cargo.toml`** — arrow pins aligned to 59. This crate is deliberately its own workspace with a gitignored lockfile, so it resolves arrow *independently* of the root; the original `>=56.0.0` could have selected a different arrow major than the `pgpq` it path-depends on, and the two would not have shared types.
- **`py/src/template.py`** — the codegen templates emitted `#[pyclass(module = "pgpq._pgpq")]` without `from_py_object`, so a regeneration would have silently reverted the pyo3 0.29 opt-ins. The rationale is in Python comments *outside* the template strings — inside them it would be emitted into the generated Rust, where `#` is not a comment.
- **`core/benches/yellow_cab_dataset.rs`** — drive-by fix, unrelated to the bump but in a file the criterion migration already touches: `benchmark_nyc_taxi_full` called `setup(Some(100))`, byte-identical to `benchmark_nyc_taxi_small`, so the "full" benchmark has never encoded more than that small slice. Now `setup(None)`.

**maturin sync:** `MATURIN_VERSION: "v1.14.1"` in `python-package.yaml` still matches the locked maturin 1.14.1 — neither moved, so no workflow edit was needed. maturin 1.14.1 built both pyo3-0.29 extension modules without complaint.

Two local-environment notes for anyone re-running the Python suite on macOS: the `testing.postgresql` fixture needs Homebrew `postgresql@17` on `PATH` (otherwise `command not found`) **and** a UTF-8 `LC_ALL`/`LANG` (otherwise `initdb` fails to launch). Both are pre-existing and unrelated to this change; CI is unaffected.

## Follow-ups (not in this PR)

- The arrow bump changes pgpq's public API surface (arrow 59 types), so the next `pgpq` crate release is semver-major. #66 suggests batching it with #69's no-panic API change to spend one breaking release instead of two.
- No CI job enforces the declared MSRV — `rust-version` is verified by hand here. Worth a `dtolnay/rust-toolchain@1.85` check job if the value is meant to stay honest.
- CI runs `cargo clippy --locked --all -- -D warnings`, which does **not** lint benches. The deprecated `criterion::black_box` calls fixed here had been warning locally for a while without CI noticing; `--all-targets` would have caught them. Deliberately not changed in this PR, which touches no workflows.
- `core/Cargo.toml` is now a mix of pinned caret ranges (mine) and open `>=` ranges (`proptest = ">=1.4.0"` from #78). Left as-is rather than restyling someone else's declaration, but worth unifying.
- The unused-`anyhow` removal listed in #69 is done here; drop it there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
