### PR TITLE
Fix `default-features` ignored warning for arrow-array

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ rust-version = "1.84"
 
 [workspace.dependencies]
 arrow = ">=56.0.0"
-arrow-array = ">=56.0.0"
+arrow-array = { version = ">=56.0.0", default-features = false }
 arrow-schema = ">=56.0.0"
 arrow-json = ">=56.0.0"
 arrow-ipc = ">=56.0.0"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -15,13 +15,10 @@ authors = ["Adrian Garcia Badaracco <dev@adriangb.com>"]
 [dependencies]
 bytes = "^1.4.0"
 arrow-schema.workspace = true
+arrow-array.workspace = true
 enum_dispatch = "0.3.11"
 anyhow = "1.0.70"
 thiserror = "1.0.40"
-
-[dependencies.arrow-array]
-workspace = true
-default-features = false
 
 [dev-dependencies]
 rstest = ">=0.16.0"


### PR DESCRIPTION
## Problem

Every `cargo` invocation on this workspace printed:

```
core/Cargo.toml: `default-features` is ignored for arrow-array, since `default-features` was not specified for `workspace.dependencies.arrow-array`, this could become a hard error in the future
```

`core/Cargo.toml` inherited `arrow-array` from the workspace *and* set `default-features = false` locally. When a dependency is inherited, Cargo takes `default-features` from the workspace declaration and ignores the member's — hence the warning, and the note that it may become a hard error.

## Fix

Declare `default-features = false` once, on the workspace dependency in the root `Cargo.toml`, and let `core` inherit it plainly:

```toml
# root Cargo.toml
arrow-array = { version = ">=56.0.0", default-features = false }

# core/Cargo.toml
arrow-array.workspace = true
```

`core` is the only crate that depends on `arrow-array` directly, so moving the flag to the workspace changes nothing for the other members. `pgpq` is published to crates.io, and inherited fields are flattened at publish time, so the published manifest keeps `default-features = false` exactly as before.

## Why this direction rather than dropping the flag

`arrow-array` declares no `default` feature at all — only `ffi` and `force_validate` — so `default-features = false` is a no-op for it today, and simply deleting it would have been equally correct for the current version. Keeping it on the workspace declaration costs nothing and preserves the original intent in case a future `arrow-array` release adds default features, which the open-ended `>=56.0.0` requirement would pick up.

## Verification

- `cargo check --locked --workspace` and `--all-targets`: no `default-features` warning, builds clean. The only remaining warnings are pre-existing `criterion::black_box` deprecations in the benches, untouched by this change.
- Feature resolution is unchanged. `cargo tree --workspace -e features -i arrow-array` resolves the same set before and after (`default` and `ffi`, both pulled in via `arrow`'s `pyarrow` feature from the `py`/`json` crates).
- `Cargo.lock` is unmodified.
- `cargo test --locked -p pgpq --lib`: 2 passed, 0 failed.

Pre-existing on `main`; independent of #73/#74.

🤖 Generated with [Claude Code](https://claude.com/claude-code)