### PR TITLE
tests(py): don't draw lone surrogates into a pyarrow string column

### DIFF
--- a/py/test_pgpq/test_pgpq.py
+++ b/py/test_pgpq/test_pgpq.py
@@ -346,6 +346,11 @@ def test_roundtrip_custom_encoding_to_jsonb(dbconn: Connection) -> None:
 #: Column types and the values to fill them with. Deliberately primitive: decimals are
 #: excluded because the Rust suite documents open encoder bugs there, and ``\x00`` is
 #: excluded from text because Postgres rejects it in ``text`` regardless of pgpq.
+#:
+#: Surrogates (category ``Cs``) are excluded too: ``st.text()`` will happily draw a lone
+#: ``\ud800``, which is a valid `str` but has no UTF-8 encoding, so ``pa.array`` raises
+#: while *building* the example. That made this test fail at random, on data that never
+#: reached pgpq.
 _COLUMN_TYPES: list[tuple[pa.DataType, st.SearchStrategy[Any]]] = [
     (pa.int16(), st.integers(min_value=-(2**15), max_value=2**15 - 1)),
     (pa.int32(), st.integers(min_value=-(2**31), max_value=2**31 - 1)),
@@ -354,7 +359,12 @@ _COLUMN_TYPES: list[tuple[pa.DataType, st.SearchStrategy[Any]]] = [
     (pa.bool_(), st.booleans()),
     (
         pa.string(),
-        st.text(alphabet=st.characters(blacklist_characters="\x00"), max_size=32),
+        st.text(
+            alphabet=st.characters(
+                blacklist_characters="\x00", blacklist_categories=("Cs",)
+            ),
+            max_size=32,
+        ),
     ),
     (pa.large_binary(), st.binary(max_size=32)),
 ]


### PR DESCRIPTION
`test_roundtrip_arbitrary_primitive_tables` fails at random on `main`:

```
UnicodeEncodeError: 'utf-8' codec can't encode character '\ud800' in position 0: surrogates not allowed
while generating 'table' from _mixed_tables()
```

`st.text()` draws from all of Unicode including the surrogate range. A lone `\ud800` is a
perfectly valid Python `str` but has no UTF-8 encoding, so `pa.array` raises while **building
the example** — the failure happens in the generator, before pgpq is involved at all, which is
why the traceback has nothing to do with encoding.

The strategy already excluded `\x00` (Postgres rejects it in `text`); this adds the surrogate
category `Cs` next to it, with the reasoning recorded inline.

Found while cutting 0.12.0 — it reproduces on plain `main`, so it has been an occasional
unexplained CI failure waiting to happen. Verified with 8 random hypothesis seeds after the fix,
all green, plus the full Python suite (25 passed) against a real Postgres.