### PR TITLE
Release pgpq 0.12.0 and arrow-json 0.10.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "_arrow_json"
-version = "0.11.1"
+version = "0.12.0"
 dependencies = [
  "arrow",
  "arrow-json",
@@ -15,7 +15,7 @@ dependencies = [
 
 [[package]]
 name = "_pgpq"
-version = "0.11.1"
+version = "0.12.0"
 dependencies = [
  "arrow",
  "arrow-schema",
@@ -1993,7 +1993,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "pgpq"
-version = "0.11.1"
+version = "0.12.0"
 dependencies = [
  "arrow",
  "arrow-array",

--- a/README.md
+++ b/README.md
@@ -41,43 +41,73 @@ See [core](./core).
 
 ## Data type support
 
-We currently support nearly all scalar data types as well as List/Array data types.
-There's no reason we can't support struct data types as well.
+We support nearly all scalar data types, all three of Arrow's list layouts, and structs
+(as Postgres composite types).
 
-|   Arrow                   |   Postgres       |
-|---------------------------|------------------|
-|   Boolean                 |   BOOL           |
-|   UInt8                   |   INT2           |
-|   UInt16                  |   INT4           |
-|   UInt32                  |   INT8           |
-|   UInt64                  |   NUMERIC        |
-|   Int8                    |   CHAR,INT2      |
-|   Int16                   |   INT2           |
-|   Int32                   |   INT4           |
-|   Int64                   |   INT8           |
-|   Float16                 |   FLOAT4         |
-|   Float32                 |   FLOAT4         |
-|   Float64                 |   FLOAT8         |
-|   Decimal32               |   NUMERIC        |
-|   Decimal64               |   NUMERIC        |
-|   Decimal128              |   NUMERIC        |
-|   Timestamp(Nanosecond)   |   Not supported  |
-|   Timestamp(Microsecond)  |   TIMESTAMP      |
-|   Timestamp(Millisecond)  |   TIMESTAMP      |
-|   Timestamp(Second)       |   TIMESTAMP      |
-|   Date32                  |   DATE           |
-|   Date64                  |   Not supported  |
-|   Time32(Millisecond)     |   TIME           |
-|   Time32(Second)          |   TIME           |
-|   Time64(Nanosecond)      |   Not supported  |
-|   Time64(Microsecond)     |   TIME           |
-|   Duration(Nanosecond)    |   Not supported  |
-|   Duration(Microsecond)   |   INTERVAL       |
-|   Duration(Millisecond)   |   INTERVAL       |
-|   Duration(Second)        |   INTERVAL       |
-|   String                  |   TEXT,JSONB     |
-|   Binary                  |   BYTEA          |
-|   List\<T\>               |   Array\<T\>     |
+|   Arrow                   |   Postgres              |
+|---------------------------|-------------------------|
+|   Boolean                 |   BOOL                  |
+|   UInt8                   |   INT2                  |
+|   UInt16                  |   INT4                  |
+|   UInt32                  |   INT8                  |
+|   UInt64                  |   NUMERIC               |
+|   Int8                    |   INT2                  |
+|   Int16                   |   INT2                  |
+|   Int32                   |   INT4                  |
+|   Int64                   |   INT8                  |
+|   Float16                 |   FLOAT4                |
+|   Float32                 |   FLOAT4                |
+|   Float64                 |   FLOAT8                |
+|   Decimal32               |   NUMERIC               |
+|   Decimal64               |   NUMERIC               |
+|   Decimal128              |   NUMERIC               |
+|   Timestamp(Nanosecond)   |   Not supported         |
+|   Timestamp(Microsecond)  |   TIMESTAMP             |
+|   Timestamp(Millisecond)  |   TIMESTAMP             |
+|   Timestamp(Second)       |   TIMESTAMP             |
+|   Date32                  |   DATE                  |
+|   Date64                  |   Not supported         |
+|   Time32(Millisecond)     |   TIME                  |
+|   Time32(Second)          |   TIME                  |
+|   Time64(Nanosecond)      |   Not supported         |
+|   Time64(Microsecond)     |   TIME                  |
+|   Duration(Nanosecond)    |   Not supported         |
+|   Duration(Microsecond)   |   INTERVAL              |
+|   Duration(Millisecond)   |   INTERVAL              |
+|   Duration(Second)        |   INTERVAL              |
+|   Utf8                    |   TEXT, JSON, JSONB     |
+|   LargeUtf8               |   TEXT, JSON, JSONB     |
+|   Utf8View                |   TEXT, JSON, JSONB     |
+|   Binary                  |   BYTEA                 |
+|   LargeBinary             |   BYTEA                 |
+|   FixedSizeBinary         |   BYTEA                 |
+|   List\<T\>               |   Array\<T\>            |
+|   LargeList\<T\>          |   Array\<T\>            |
+|   FixedSizeList\<T\>      |   Array\<T\>            |
+|   Struct                  |   Composite type        |
+
+The non-default output types (`JSON`/`JSONB` for strings) are selected per column with
+`StringEncoderBuilder::new_with_output`.
+
+### Structs and composite types
+
+A struct column becomes a Postgres composite type, and `PostgresSchema::ddl` emits the
+`CREATE TYPE` for it using the Arrow field names.
+
+A composite's OID goes on the wire wherever one is *nested* — a struct inside a struct, or an
+array of structs — and Postgres allocates that OID when the type is created, so it has to come
+from the database you are loading into:
+
+```sql
+select oid from pg_type where typname = 'my_struct_t';
+```
+
+```rust
+let encoder = ArrowToPostgresBinaryEncoder::try_new(&schema)?
+    .with_composite_oids(&HashMap::from([("my_struct_t".to_string(), oid)]))?;
+```
+
+Top-level struct columns need nothing extra: binary COPY declares no column types.
 
 ### JSONB support
 

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pgpq"
-version = "0.11.1"
+version = "0.12.0"
 edition.workspace = true
 rust-version.workspace = true
 description = "Encode Apache Arrow `RecordBatch`es to Postgres' native binary format"

--- a/json/Cargo.toml
+++ b/json/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "_arrow_json"
-version = "0.11.1"
+version = "0.12.0"
 edition.workspace = true
 rust-version.workspace = true
 readme = "README.md"

--- a/json/pyproject.toml
+++ b/json/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "arrow-json"
-version = "0.9.0"
+version = "0.10.0"
 description = "Arrow -> JSON encoder"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/py/Cargo.toml
+++ b/py/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "_pgpq"
-version = "0.11.1"
+version = "0.12.0"
 edition.workspace = true
 rust-version.workspace = true
 readme = "README.md"

--- a/py/pyproject.toml
+++ b/py/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pgpq"
-version = "0.11.1"
+version = "0.12.0"
 description = "Arrow -> PostgreSQL encoder"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/uv.lock
+++ b/uv.lock
@@ -117,7 +117,7 @@ wheels = [
 
 [[package]]
 name = "arrow-json"
-version = "0.9.0"
+version = "0.10.0"
 source = { editable = "json" }
 dependencies = [
     { name = "pyarrow" },
@@ -1691,7 +1691,7 @@ wheels = [
 
 [[package]]
 name = "pgpq"
-version = "0.11.1"
+version = "0.12.0"
 source = { editable = "py" }
 dependencies = [
     { name = "pyarrow" },


### PR DESCRIPTION
**Merging this publishes.** `detect-release` sees a version the registry does not have and the
release jobs push `pgpq` to crates.io and PyPI, and `arrow-json` to PyPI.

- `pgpq` 0.11.1 → **0.12.0** (`core/Cargo.toml`, `py/Cargo.toml`, `py/pyproject.toml`)
- `arrow-json` 0.9.0 → **0.10.0** (`json/pyproject.toml`; `json/Cargo.toml` tracks the workspace
  version as it always has)
- `Cargo.lock` and `uv.lock` regenerated

## What's in 0.12.0

The breaking changes were deliberately batched so they would cost one release rather than several.

**Breaking**
- **arrow 56 → 59** and the public API that moves with it (#82).
- **`write_header` returns `Result`** — the encoder state machine reports misuse instead of
  aborting the host process (#89).
- **Nested composites require their OID** (#96/#102). `PostgresType::UserDefined` carries
  `oid: Option<u32>`; supply it with `ArrowToPostgresBinaryEncoder::with_composite_oids`, keyed by
  the type name the DDL creates, and use `composite_type_names()` to learn which names to look up.
  This replaces a hard-coded `16385` that silently collided with real user OIDs on any database
  that had ever created a user-defined type.
- **`Int8` can no longer be written as `Char`** (#95/#101). It declared `bpchar` for a two-byte
  INT2 payload, so Postgres rejected every value; it is refused at build time now.
- **Composite DDL uses the Arrow field names** rather than positional `f0`, `f1` (#97/#99), and
  every identifier the DDL emits is quoted.

**Fixes**
- `Json.oid()` returned jsonb's 3802 instead of json's 114, so a `json[]` column was rejected by
  the server (#96/#100).
- `FixedSizeBinary`/`FixedSizeList` encoders implemented; struct-with-list-field panic fixed (#94).

**Performance**
- Encoding is roughly **2× faster** on the NYC taxi benchmark, wire format byte-identical (#98).

**Also**
- `StructEncoderBuilder` is exported to typed Python (#97/#99).
- Generative-suite polish: sign-of-zero fidelity, unified float equality, wider fuzz coverage,
  and the snapshot corpus blind spots closed (#93).

The README's data type table is refreshed in the same commit — it still claimed structs were
unsupported, still offered `CHAR` for `Int8`, and omitted `LargeUtf8`, `Utf8View`, `LargeBinary`,
`FixedSizeBinary`, `LargeList` and `FixedSizeList`. It now also documents the composite-OID flow.

## Verification

`cargo test --locked --all-features` (290 tests) and the full `pytest` suite (25, including the
9 Postgres-backed ones) green locally against a real server, plus `cargo fmt`, `clippy`,
`uv lock --check` and `pre-commit`.